### PR TITLE
Various editor interaction fixes.

### DIFF
--- a/editor/imgui.ini
+++ b/editor/imgui.ini
@@ -375,6 +375,16 @@ Pos=610,270
 Size=700,450
 Collapsed=0
 
+[Window][Save Layout As..##filebrowser_140698604041488]
+Pos=290,286
+Size=700,450
+Collapsed=0
+
+[Window][Save Layout As..##filebrowser_140696898885008]
+Pos=290,286
+Size=700,450
+Collapsed=0
+
 [Docking][Data]
 DockSpace         ID=0x8B93E3BD Window=0xA787BDB4 Pos=1897,282 Size=1280,1003 Split=Y Selected=0x429E880E
   DockNode        ID=0x00000003 Parent=0x8B93E3BD SizeRef=1434,99 Split=X Selected=0xFE740DCC

--- a/editor/src/editor/editor_layer.cpp
+++ b/editor/src/editor/editor_layer.cpp
@@ -285,6 +285,7 @@ void EditorLayer::NewLayout(bool discard) {
         m_lockedNodes.clear();
         Rebuild();
         for (auto&& [panelId, panel] : m_panels) {
+            panel->OnNewLayout();
             panel->OnLayoutLoaded();
         }
     }
@@ -428,7 +429,7 @@ void EditorLayer::MenuFuncSaveLayoutAs() {
 void EditorLayer::CopyEntity() {
     m_copiedEntities.clear();
     for (auto&& node : m_selection) {
-        m_copiedEntities.push_back(node->GetLayoutEntity());
+        m_copiedEntities.push_back(node->GetLayoutEntity()->Clone(moth_ui::LayoutEntity::CloneType::Deep));
     }
 }
 

--- a/editor/src/editor/panels/editor_panel.h
+++ b/editor/src/editor/panels/editor_panel.h
@@ -26,6 +26,7 @@ public:
     bool IsExposed() const { return m_exposed; }
     bool IsFocused() const { return m_focused; }
 
+    virtual void OnNewLayout() {}
     virtual void OnLayoutLoaded() {}
     virtual void OnShutdown() {}
 

--- a/editor/src/editor/panels/editor_panel_animation.cpp
+++ b/editor/src/editor/panels/editor_panel_animation.cpp
@@ -27,6 +27,11 @@ EditorPanelAnimation::EditorPanelAnimation(EditorLayer& editorLayer, bool visibl
     : EditorPanel(editorLayer, "Animation", visible, true) {
 }
 
+void EditorPanelAnimation::OnNewLayout() {
+    m_currentFrame = 0;
+    m_editorLayer.GetConfig().CurrentAnimationFrame = 0;
+}
+
 void EditorPanelAnimation::OnLayoutLoaded() {
     ClearSelections();
 

--- a/editor/src/editor/panels/editor_panel_animation.h
+++ b/editor/src/editor/panels/editor_panel_animation.h
@@ -32,6 +32,7 @@ public:
     EditorPanelAnimation(EditorLayer& editorLayer, bool visible);
     virtual ~EditorPanelAnimation() = default;
 
+    void OnNewLayout() override;
     void OnLayoutLoaded() override;
     void OnShutdown() override;
 

--- a/editor/src/editor/panels/editor_panel_canvas.h
+++ b/editor/src/editor/panels/editor_panel_canvas.h
@@ -131,10 +131,14 @@ private:
 
     void UpdateDisplayTexture(moth_ui::IntVec2 const& displaySize);
 
+    void BeginSelectionGrab(moth_ui::IntVec2 const& worldPosition);
+    void EndSelectionGrab();
+
     void OnMouseClicked(moth_ui::IntVec2 const& appPosition);
     void OnMouseReleased(moth_ui::IntVec2 const& appPosition);
     void OnMouseMoved(moth_ui::IntVec2 const& appPosition);
 
+    std::shared_ptr<moth_ui::Node> GetAtPoint(moth_ui::IntVec2 const& selectionPoint);
     void SelectInRect(moth_ui::IntRect const& selectionRect);
 
     void UpdateInput();

--- a/include/moth_ui/animation_track.h
+++ b/include/moth_ui/animation_track.h
@@ -125,6 +125,7 @@ namespace moth_ui {
         };
 
         AnimationTrack() = default;
+        AnimationTrack(AnimationTrack const& other);
         explicit AnimationTrack(Target target);
         AnimationTrack(Target target, float initialValue);
         explicit AnimationTrack(nlohmann::json const& json);

--- a/src/animation_track.cpp
+++ b/src/animation_track.cpp
@@ -4,13 +4,20 @@
 #include "moth_ui/utils/math_utils.h"
 
 namespace moth_ui {
-    AnimationTrack::AnimationTrack(Target target, float initialValue)
-        : m_target(target) {
-        m_keyframes.push_back(std::make_unique<Keyframe>( 0, initialValue ));
+    AnimationTrack::AnimationTrack(AnimationTrack const& other)
+        : m_target(other.m_target) {
+        for (auto&& keyframe : other.m_keyframes) {
+            m_keyframes.push_back(std::make_shared<Keyframe>(*keyframe));
+        }
     }
 
     AnimationTrack::AnimationTrack(Target target)
         : m_target(target) {
+    }
+
+    AnimationTrack::AnimationTrack(Target target, float initialValue)
+        : m_target(target) {
+        m_keyframes.push_back(std::make_unique<Keyframe>(0, initialValue));
     }
 
     AnimationTrack::AnimationTrack(nlohmann::json const& json) {


### PR DESCRIPTION
Fixing copy/paste behaviour. Now copies will make a hard copy of the entity so modifying the source entity and then pasting again will not paste the modified source values.
Fixing selection interaction behaviour. Clicking a non selected entity and then dragging will now properly drag the entity. Fixes #41