### PR TITLE
fix: Made the nlohmann_json headers transitive.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -7,9 +7,10 @@ class MothUI(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeToolchain", "CMakeDeps"
     exports_sources = "CMakeLists.txt", "include/*", "src/*"
+    package_type = "static-library"
 
     def requirements(self):
-        self.requires("nlohmann_json/3.11.2")
+        self.requires("nlohmann_json/3.11.2", transitive_headers=True)
         self.requires("magic_enum/0.7.3")
         self.requires("range-v3/0.12.0")
         self.requires("fmt/10.0.0")


### PR DESCRIPTION
Just learned about the transitive_headers flag on requirements. Since the json headers are included in public headers the json headers should be transitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the package configuration to support static library builds.
  - Improved external dependency integration for smoother handling of transitive headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->