### PR TITLE
Add LayoutEntityFlipbook constructor and discrete animation tracks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ set(PUBLIC_HEADERS
 	include/moth_ui/animation/animation_track_controller.h
 	include/moth_ui/animation/animation_track.h
 	include/moth_ui/animation/clip_controller.h
+	include/moth_ui/animation/discrete_animation_track.h
+	include/moth_ui/animation/discrete_animation_track_controller.h
 	include/moth_ui/animation/keyframe.h
 	include/moth_ui/context.h
 	include/moth_ui/events/event_animation.h
@@ -81,6 +83,8 @@ set(SOURCES ${SOURCES}
 	src/animation/animation_event.cpp
 	src/animation/animation_track_controller.cpp
 	src/animation/animation_track.cpp
+	src/animation/discrete_animation_track.cpp
+	src/animation/discrete_animation_track_controller.cpp
 	src/animation/keyframe.cpp
 	src/context.cpp
 	src/logger.cpp

--- a/include/moth_ui/animation/animation_controller.h
+++ b/include/moth_ui/animation/animation_controller.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include "moth_ui/animation/animation_track.h"
 #include "moth_ui/moth_ui_fwd.h"
 
+#include <functional>
+#include <string_view>
 #include <vector>
 #include <memory>
 
@@ -28,6 +31,26 @@ namespace moth_ui {
          */
         void SetFrame(float frame);
 
+        /**
+         * @brief Evaluates only discrete tracks at @p frame, firing change callbacks.
+         *
+         * Used by Node::Refresh() (editor scrub) which handles continuous tracks itself.
+         * @param frame Frame index (may be fractional).
+         */
+        void SetFrameDiscrete(float frame);
+
+        /// @brief Removes all registered discrete callbacks (used before re-registering on reload).
+        void ClearDiscreteCallbacks();
+
+        /**
+         * @brief Registers a callback to be invoked when a discrete track changes value.
+         *
+         * If the entity has no discrete track for @p target the registration is a no-op.
+         * @param target   The discrete track target to observe.
+         * @param callback Called with the new string value when it changes at a new frame.
+         */
+        void RegisterDiscreteCallback(AnimationTrack::Target target, std::function<void(std::string_view)> callback);
+
         AnimationController(AnimationController const&) = delete;
         AnimationController(AnimationController&&) = default;
         AnimationController& operator=(AnimationController const&) = delete;
@@ -36,5 +59,6 @@ namespace moth_ui {
     private:
         Node* m_node = nullptr;
         std::vector<std::unique_ptr<AnimationTrackController>> m_trackControllers;
+        std::vector<std::unique_ptr<DiscreteAnimationTrackController>> m_discreteControllers;
     };
 }

--- a/include/moth_ui/animation/animation_track.h
+++ b/include/moth_ui/animation/animation_track.h
@@ -37,6 +37,8 @@ namespace moth_ui {
             ColorBlue,     ///< Blue colour component [0,1].
             ColorAlpha,    ///< Alpha colour component [0,1].
             Rotation,      ///< Clockwise rotation in degrees.
+            FlipbookClip,    ///< Flipbook clip name (discrete string, step-interpolated).
+            FlipbookPlaying, ///< Flipbook play/pause state as "1"/"0" (discrete, step-interpolated).
         };
 
         /// @brief All targets that are continuously interpolated (excludes Unknown).
@@ -54,6 +56,12 @@ namespace moth_ui {
             Target::ColorBlue,
             Target::ColorAlpha,
             Target::Rotation,
+        };
+
+        /// @brief All targets that are step-interpolated string values (discrete tracks).
+        static constexpr std::array<Target, 2> DiscreteTargets{
+            Target::FlipbookClip,
+            Target::FlipbookPlaying,
         };
 
         AnimationTrack(AnimationTrack const& other);

--- a/include/moth_ui/animation/discrete_animation_track.h
+++ b/include/moth_ui/animation/discrete_animation_track.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "moth_ui/animation/animation_track.h"
+
+#include <nlohmann/json_fwd.hpp>
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace moth_ui {
+    /**
+     * @brief A non-interpolated animation track that stores string values at specific frames.
+     *
+     * Unlike AnimationTrack (which interpolates floats), a DiscreteAnimationTrack
+     * steps instantly to the value of the last keyframe at or before the current
+     * frame. Suitable for targets such as FlipbookClip (clip name) and
+     * FlipbookPlaying (play/pause state).
+     */
+    class DiscreteAnimationTrack {
+    public:
+        /// @brief Ordered list of (frame, value) pairs sorted ascending by frame.
+        using KeyframeList = std::vector<std::pair<int, std::string>>;
+
+        explicit DiscreteAnimationTrack(AnimationTrack::Target target);
+        DiscreteAnimationTrack(DiscreteAnimationTrack const& other) = default;
+        DiscreteAnimationTrack(DiscreteAnimationTrack&&) = default;
+        DiscreteAnimationTrack& operator=(DiscreteAnimationTrack const&) = default;
+        DiscreteAnimationTrack& operator=(DiscreteAnimationTrack&&) = default;
+        ~DiscreteAnimationTrack() = default;
+
+        /// @brief Returns the property this track animates.
+        AnimationTrack::Target GetTarget() const { return m_target; }
+
+        /// @brief Returns a mutable reference to the keyframe list.
+        KeyframeList& Keyframes() { return m_keyframes; }
+
+        /// @brief Returns a const reference to the keyframe list.
+        KeyframeList const& Keyframes() const { return m_keyframes; }
+
+        /**
+         * @brief Returns the value at the last keyframe at or before @p frame.
+         *
+         * Returns an empty string if no keyframe precedes the given frame.
+         * @param frame Frame index.
+         */
+        std::string const& GetValueAtFrame(int frame) const;
+
+        /**
+         * @brief Returns a reference to the value at @p frame, creating an empty entry if absent.
+         * @param frame Frame index.
+         */
+        std::string& GetOrCreateKeyframe(int frame);
+
+        /**
+         * @brief Returns a pointer to the value at the given frame, or @c nullptr if absent.
+         * @param frame Frame index.
+         */
+        std::string* GetKeyframe(int frame);
+
+        /**
+         * @brief Deletes the keyframe at the given frame number.
+         * @param frame Frame index.
+         */
+        void DeleteKeyframe(int frame);
+
+        /// @brief Sorts keyframes by ascending frame index.
+        void SortKeyframes();
+
+        friend void to_json(nlohmann::json& json, DiscreteAnimationTrack const& track);
+        friend void from_json(nlohmann::json const& json, DiscreteAnimationTrack& track);
+
+    private:
+        AnimationTrack::Target m_target = AnimationTrack::Target::Unknown;
+        KeyframeList m_keyframes;
+    };
+}

--- a/include/moth_ui/animation/discrete_animation_track_controller.h
+++ b/include/moth_ui/animation/discrete_animation_track_controller.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "moth_ui/animation/discrete_animation_track.h"
+
+#include <functional>
+#include <string_view>
+
+namespace moth_ui {
+    /**
+     * @brief Drives a DiscreteAnimationTrack, invoking a callback only when the value changes.
+     *
+     * The callback receives the new value as a @c std::string_view whenever
+     * SetFrame() moves into a region with a different step value.
+     */
+    class DiscreteAnimationTrackController {
+    public:
+        /**
+         * @brief Constructs the controller.
+         * @param track    The discrete track to evaluate.
+         * @param callback Called with the new value when it changes at a new frame.
+         */
+        DiscreteAnimationTrackController(DiscreteAnimationTrack const& track, std::function<void(std::string_view)> callback);
+
+        DiscreteAnimationTrackController(DiscreteAnimationTrackController const&) = delete;
+        DiscreteAnimationTrackController(DiscreteAnimationTrackController&&) = default;
+        DiscreteAnimationTrackController& operator=(DiscreteAnimationTrackController const&) = delete;
+        DiscreteAnimationTrackController& operator=(DiscreteAnimationTrackController&&) = default;
+        ~DiscreteAnimationTrackController() = default;
+
+        /**
+         * @brief Evaluates the track at @p frame and invokes the callback if the value changed.
+         * @param frame Frame index (truncated to int for step evaluation).
+         */
+        void SetFrame(float frame);
+
+        /// @brief Resets the last-seen value so the callback fires on the next SetFrame().
+        void Reset();
+
+    private:
+        DiscreteAnimationTrack const* m_track = nullptr;
+        std::function<void(std::string_view)> m_callback;
+        std::string m_lastValue;
+        bool m_initialized = false;
+    };
+}

--- a/include/moth_ui/layout/layout_entity.h
+++ b/include/moth_ui/layout/layout_entity.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "moth_ui/animation/animation_track.h"
+#include "moth_ui/animation/discrete_animation_track.h"
 #include "moth_ui/layout/layout_entity_type.h"
 #include "moth_ui/moth_ui_fwd.h"
 #include "moth_ui/utils/color.h"
 #include "moth_ui/utils/transform.h"
 
 #include <filesystem>
+#include <map>
 #include <nlohmann/json_fwd.hpp>
 
 namespace moth_ui {
@@ -128,7 +130,8 @@ namespace moth_ui {
         bool m_visible = true;            ///< Default visibility of the instantiated node.
         BlendMode m_blend = BlendMode::Replace; ///< Default blend mode of the instantiated node.
         FloatVec2 m_pivot = kDefaultPivot; ///< Rotation pivot as a normalised [0,1] fraction of the node's bounds. Default is centre.
-        std::map<AnimationTrack::Target, std::unique_ptr<AnimationTrack>> m_tracks; ///< Per-property keyframe tracks.
+        std::map<AnimationTrack::Target, std::unique_ptr<AnimationTrack>> m_tracks; ///< Per-property continuous keyframe tracks.
+        std::map<AnimationTrack::Target, DiscreteAnimationTrack> m_discreteTracks; ///< Per-property discrete (string, step) keyframe tracks.
         std::shared_ptr<LayoutEntity> m_hardReference; ///< Immutable source data used to compute overrides for sublayout refs.
 
         LayoutEntity& operator=(LayoutEntity const&) = delete;

--- a/include/moth_ui/layout/layout_entity_flipbook.h
+++ b/include/moth_ui/layout/layout_entity_flipbook.h
@@ -15,6 +15,7 @@ namespace moth_ui {
     public:
         explicit LayoutEntityFlipbook(LayoutRect const& initialBounds);
         explicit LayoutEntityFlipbook(LayoutEntityGroup* parent);
+        LayoutEntityFlipbook(LayoutRect const& initialBounds, std::filesystem::path const& flipbookPath);
 
         std::shared_ptr<LayoutEntity> Clone(CloneType cloneType) override;
         LayoutEntityType GetType() const override { return LayoutEntityType::Flipbook; }

--- a/include/moth_ui/layout/layout_entity_flipbook.h
+++ b/include/moth_ui/layout/layout_entity_flipbook.h
@@ -24,7 +24,5 @@ namespace moth_ui {
         bool Deserialize(nlohmann::json const& json, SerializeContext const& context) override;
 
         std::filesystem::path m_flipbookPath; ///< Path to the .flipbook.json descriptor file.
-        std::string m_clipName;               ///< Clip to activate on load. Empty means no clip is pre-selected.
-        bool m_autoplay = false;              ///< If @c true, playback begins automatically after the clip is loaded.
     };
 }

--- a/include/moth_ui/layout/layout_entity_flipbook.h
+++ b/include/moth_ui/layout/layout_entity_flipbook.h
@@ -6,10 +6,13 @@ namespace moth_ui {
     /**
      * @brief Layout entity that describes a flipbook (sprite-sheet animation) node.
      *
-     * Stores the path to the .flipbook.json descriptor, an optional initial clip
-     * name, and an autoplay flag. When instantiated into a NodeFlipbook, the named
-     * clip is activated on load and playback begins automatically if @c m_autoplay
-     * is @c true.
+     * Stores the path to the .flipbook.json descriptor. Clip selection and
+     * playback state are managed by discrete animation tracks
+     * (@c AnimationTrack::Target::FlipbookClip and
+     * @c AnimationTrack::Target::FlipbookPlaying) rather than per-entity fields.
+     * When instantiated into a NodeFlipbook, the active clip and initial play
+     * state are determined by those tracks at frame 0. To start playback
+     * automatically, set the @c FlipbookPlaying track value to @c "1" at frame 0.
      */
     class LayoutEntityFlipbook : public LayoutEntity {
     public:

--- a/include/moth_ui/moth_ui_fwd.h
+++ b/include/moth_ui/moth_ui_fwd.h
@@ -82,6 +82,8 @@ namespace moth_ui {
     class AnimationController;
     class AnimationTrackController;
     class AnimationClipController;
+    class DiscreteAnimationTrack;
+    class DiscreteAnimationTrackController;
     struct ClipController;
 
     // -------------------------------------------------------------------------

--- a/include/moth_ui/nodes/node_flipbook.h
+++ b/include/moth_ui/nodes/node_flipbook.h
@@ -111,6 +111,7 @@ namespace moth_ui {
         int m_currentFrame = 0;                           ///< Current frame index within the full sheet grid.
         float m_accumulatedMs = 0.0f;                     ///< Accumulated time since the last frame advance in milliseconds.
         bool m_playing = false;                           ///< Whether the current clip is advancing.
+        bool m_pendingStartedEvent = false;               ///< True when EventFlipbookStarted could not be sent during construction and should be fired on the next Update().
 
         void ReloadEntityInternal() override;
         void DrawInternal() override;

--- a/include/moth_ui/nodes/node_flipbook.h
+++ b/include/moth_ui/nodes/node_flipbook.h
@@ -44,9 +44,12 @@ namespace moth_ui {
          * @brief Loads a flipbook from a descriptor file path.
          *
          * Resets all playback state (frame, accumulated time, playing flag) before
-         * loading. If the load succeeds and @c m_initialClipName is non-empty, that
-         * clip is activated automatically. If @c m_autoplay is also @c true,
-         * playback starts immediately.
+         * loading. After a successful load the node has no active clip and is not
+         * playing; clip selection and autoplay are driven by discrete animation
+         * tracks (@c FlipbookClip and @c FlipbookPlaying) evaluated via
+         * @c ReloadEntityPrivate() when the node is instantiated from a
+         * @c LayoutEntityFlipbook, or by explicit calls to @c SetClip() and
+         * @c SetPlaying() at runtime.
          *
          * @param path Path to the .flipbook.json descriptor file.
          */
@@ -92,6 +95,7 @@ namespace moth_ui {
         float m_accumulatedMs = 0.0f;                     ///< Accumulated time since the last frame advance in milliseconds.
         bool m_playing = false;                           ///< Whether the current clip is advancing.
         bool m_pendingStartedEvent = false;               ///< True when EventFlipbookStarted could not be sent during construction and should be fired on the next Update().
+        std::string m_pendingStartedClipName;             ///< Clip name captured when m_pendingStartedEvent was set, used to fire the correct name even if SetClip is called before Update().
 
         void ReloadEntityInternal() override;
         void DrawInternal() override;

--- a/include/moth_ui/nodes/node_flipbook.h
+++ b/include/moth_ui/nodes/node_flipbook.h
@@ -67,24 +67,6 @@ namespace moth_ui {
          */
         void SetPlaying(bool playing);
 
-        /// @brief Returns the clip name that will be activated on the next @c Load() call.
-        std::string_view GetInitialClipName() const { return m_initialClipName; }
-
-        /// @brief Returns @c true if playback starts automatically after @c Load() activates the initial clip.
-        bool GetAutoplay() const { return m_autoplay; }
-
-        /**
-         * @brief Sets the clip name to activate on the next @c Load() call.
-         * @param name Clip name, or empty to load without pre-selecting a clip.
-         */
-        void SetInitialClipName(std::string_view name) { m_initialClipName = name; }
-
-        /**
-         * @brief Controls whether playback starts automatically after @c Load() activates the initial clip.
-         * @param autoplay @c true to start playing immediately after load, @c false to load paused.
-         */
-        void SetAutoplay(bool autoplay) { m_autoplay = autoplay; }
-
         /// @brief Returns the name of the currently active clip, or empty if none is set.
         std::string_view GetCurrentClipName() const { return m_currentClipName; }
 
@@ -106,8 +88,6 @@ namespace moth_ui {
         std::optional<IFlipbook::SheetDesc> m_sheetDesc;  ///< Cached sheet geometry, populated on load.
         std::optional<IFlipbook::ClipDesc> m_currentClip; ///< Active clip description, empty if no clip is set.
         std::string m_currentClipName;                    ///< Name of the active clip, or empty if none is set.
-        std::string m_initialClipName;                    ///< Clip name to activate when Load() is called. Empty means no pre-selection.
-        bool m_autoplay = false;                          ///< Whether to start playing automatically after Load() activates the initial clip.
         int m_currentFrame = 0;                           ///< Current frame index within the full sheet grid.
         float m_accumulatedMs = 0.0f;                     ///< Accumulated time since the last frame advance in milliseconds.
         bool m_playing = false;                           ///< Whether the current clip is advancing.

--- a/src/animation/animation_controller.cpp
+++ b/src/animation/animation_controller.cpp
@@ -1,6 +1,7 @@
 #include "common.h"
 #include "moth_ui/animation/animation_controller.h"
 #include "moth_ui/animation/animation_track_controller.h"
+#include "moth_ui/animation/discrete_animation_track_controller.h"
 #include "moth_ui/layout/layout_entity.h"
 #include "moth_ui/nodes/node.h"
 
@@ -37,6 +38,8 @@ namespace {
         case AnimationTrack::Target::Rotation:
             return node->GetRotation();
         case AnimationTrack::Target::Events:
+        case AnimationTrack::Target::FlipbookClip:
+        case AnimationTrack::Target::FlipbookPlaying:
         case AnimationTrack::Target::Unknown:
             break;
         }
@@ -69,6 +72,28 @@ namespace moth_ui {
         for (auto&& track : m_trackControllers) {
             track->SetFrame(frame);
         }
+        for (auto&& track : m_discreteControllers) {
+            track->SetFrame(frame);
+        }
         m_node->RecalculateBounds();
+    }
+
+    void AnimationController::SetFrameDiscrete(float frame) {
+        for (auto&& track : m_discreteControllers) {
+            track->SetFrame(frame);
+        }
+    }
+
+    void AnimationController::ClearDiscreteCallbacks() {
+        m_discreteControllers.clear();
+    }
+
+    void AnimationController::RegisterDiscreteCallback(AnimationTrack::Target target, std::function<void(std::string_view)> callback) {
+        if (auto const layout = m_node->GetLayoutEntity()) {
+            auto it = layout->m_discreteTracks.find(target);
+            if (it != layout->m_discreteTracks.end()) {
+                m_discreteControllers.push_back(std::make_unique<DiscreteAnimationTrackController>(it->second, std::move(callback)));
+            }
+        }
     }
 }

--- a/src/animation/discrete_animation_track.cpp
+++ b/src/animation/discrete_animation_track.cpp
@@ -1,0 +1,81 @@
+#include "common.h"
+#include "moth_ui/animation/discrete_animation_track.h"
+
+#include <nlohmann/json.hpp>
+#include <algorithm>
+
+namespace moth_ui {
+    DiscreteAnimationTrack::DiscreteAnimationTrack(AnimationTrack::Target target)
+        : m_target(target) {
+    }
+
+    static std::string const s_emptyString;
+
+    std::string const& DiscreteAnimationTrack::GetValueAtFrame(int frame) const {
+        // Walk backwards to find the last keyframe at or before frame.
+        for (auto it = m_keyframes.rbegin(); it != m_keyframes.rend(); ++it) {
+            if (it->first <= frame) {
+                return it->second;
+            }
+        }
+        return s_emptyString;
+    }
+
+    std::string& DiscreteAnimationTrack::GetOrCreateKeyframe(int frame) {
+        // Find or insert in sorted order.
+        auto it = std::find_if(m_keyframes.begin(), m_keyframes.end(), [frame](auto const& kf) {
+            return kf.first >= frame;
+        });
+        if (it != m_keyframes.end() && it->first == frame) {
+            return it->second;
+        }
+        auto inserted = m_keyframes.insert(it, std::make_pair(frame, std::string{}));
+        return inserted->second;
+    }
+
+    std::string* DiscreteAnimationTrack::GetKeyframe(int frame) {
+        auto it = std::find_if(m_keyframes.begin(), m_keyframes.end(), [frame](auto const& kf) {
+            return kf.first == frame;
+        });
+        if (it != m_keyframes.end()) {
+            return &it->second;
+        }
+        return nullptr;
+    }
+
+    void DiscreteAnimationTrack::DeleteKeyframe(int frame) {
+        auto it = std::find_if(m_keyframes.begin(), m_keyframes.end(), [frame](auto const& kf) {
+            return kf.first == frame;
+        });
+        if (it != m_keyframes.end()) {
+            m_keyframes.erase(it);
+        }
+    }
+
+    void DiscreteAnimationTrack::SortKeyframes() {
+        std::sort(m_keyframes.begin(), m_keyframes.end(), [](auto const& a, auto const& b) {
+            return a.first < b.first;
+        });
+    }
+
+    void to_json(nlohmann::json& json, DiscreteAnimationTrack const& track) {
+        json["target"] = track.m_target;
+        auto keyframesJson = nlohmann::json::array();
+        for (auto const& [frame, value] : track.m_keyframes) {
+            keyframesJson.push_back({ { "frame", frame }, { "value", value } });
+        }
+        json["keyframes"] = keyframesJson;
+    }
+
+    void from_json(nlohmann::json const& json, DiscreteAnimationTrack& track) {
+        track.m_target = json.value("target", AnimationTrack::Target::Unknown);
+        track.m_keyframes.clear();
+        if (json.contains("keyframes")) {
+            for (auto const& kfJson : json["keyframes"]) {
+                int frame = kfJson.value("frame", 0);
+                std::string value = kfJson.value("value", std::string{});
+                track.m_keyframes.emplace_back(frame, std::move(value));
+            }
+        }
+    }
+}

--- a/src/animation/discrete_animation_track.cpp
+++ b/src/animation/discrete_animation_track.cpp
@@ -76,6 +76,7 @@ namespace moth_ui {
                 std::string value = kfJson.value("value", std::string{});
                 track.m_keyframes.emplace_back(frame, std::move(value));
             }
+            track.SortKeyframes();
         }
     }
 }

--- a/src/animation/discrete_animation_track_controller.cpp
+++ b/src/animation/discrete_animation_track_controller.cpp
@@ -1,0 +1,25 @@
+#include "common.h"
+#include "moth_ui/animation/discrete_animation_track_controller.h"
+
+namespace moth_ui {
+    DiscreteAnimationTrackController::DiscreteAnimationTrackController(DiscreteAnimationTrack const& track, std::function<void(std::string_view)> callback)
+        : m_track(&track)
+        , m_callback(std::move(callback)) {
+    }
+
+    void DiscreteAnimationTrackController::SetFrame(float frame) {
+        std::string const& value = m_track->GetValueAtFrame(static_cast<int>(frame));
+        if (!m_initialized || value != m_lastValue) {
+            m_initialized = true;
+            m_lastValue = value;
+            if (m_callback) {
+                m_callback(m_lastValue);
+            }
+        }
+    }
+
+    void DiscreteAnimationTrackController::Reset() {
+        m_initialized = false;
+        m_lastValue.clear();
+    }
+}

--- a/src/layout/layout_entity.cpp
+++ b/src/layout/layout_entity.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
 #include "moth_ui/layout/layout_entity.h"
+#include "moth_ui/animation/discrete_animation_track.h"
 #include "moth_ui/layout/layout_entity_flipbook.h"
 #include "moth_ui/layout/layout_entity_group.h"
 #include "moth_ui/layout/layout_entity_text.h"
@@ -44,7 +45,8 @@ namespace moth_ui {
         : m_id(other.m_id)
         , m_class(other.m_class)
         , m_visible(other.m_visible)
-        , m_blend(other.m_blend) {
+        , m_blend(other.m_blend)
+        , m_discreteTracks(other.m_discreteTracks) {
         if (other.m_hardReference) {
             m_hardReference = other.m_hardReference->Clone(CloneType::Shallow);
         }
@@ -56,7 +58,8 @@ namespace moth_ui {
     LayoutEntity::LayoutEntity(LayoutEntity&& other) noexcept
         : m_id(other.m_id)
         , m_visible(other.m_visible)
-        , m_blend(other.m_blend) {
+        , m_blend(other.m_blend)
+        , m_discreteTracks(std::move(other.m_discreteTracks)) {
         if (other.m_hardReference) {
             m_hardReference = other.m_hardReference->Clone(CloneType::Shallow);
         }
@@ -145,6 +148,13 @@ namespace moth_ui {
             trackJson.push_back(*track);
         }
         j["tracks"] = trackJson;
+        if (!m_discreteTracks.empty()) {
+            nlohmann::json discreteJson;
+            for (auto&& [target, track] : m_discreteTracks) {
+                discreteJson.push_back(track);
+            }
+            j["discrete_tracks"] = discreteJson;
+        }
         return j;
     }
 
@@ -165,6 +175,16 @@ namespace moth_ui {
                 auto track = std::make_unique<AnimationTrack>(trackJson);
                 m_tracks.erase(track->GetTarget());
                 m_tracks.insert(std::make_pair(track->GetTarget(), std::move(track)));
+            }
+        }
+
+        if (json.contains("discrete_tracks")) {
+            m_discreteTracks.clear();
+            for (auto const& trackJson : json["discrete_tracks"]) {
+                DiscreteAnimationTrack track(AnimationTrack::Target::Unknown);
+                from_json(trackJson, track);
+                auto target = track.GetTarget();
+                m_discreteTracks.emplace(target, std::move(track));
             }
         }
 

--- a/src/layout/layout_entity.cpp
+++ b/src/layout/layout_entity.cpp
@@ -46,6 +46,7 @@ namespace moth_ui {
         , m_class(other.m_class)
         , m_visible(other.m_visible)
         , m_blend(other.m_blend)
+        , m_pivot(other.m_pivot)
         , m_discreteTracks(other.m_discreteTracks) {
         if (other.m_hardReference) {
             m_hardReference = other.m_hardReference->Clone(CloneType::Shallow);
@@ -56,9 +57,11 @@ namespace moth_ui {
     }
 
     LayoutEntity::LayoutEntity(LayoutEntity&& other) noexcept
-        : m_id(other.m_id)
+        : m_id(std::move(other.m_id))
+        , m_class(std::move(other.m_class))
         , m_visible(other.m_visible)
         , m_blend(other.m_blend)
+        , m_pivot(other.m_pivot)
         , m_discreteTracks(std::move(other.m_discreteTracks)) {
         if (other.m_hardReference) {
             m_hardReference = other.m_hardReference->Clone(CloneType::Shallow);
@@ -149,7 +152,7 @@ namespace moth_ui {
         }
         j["tracks"] = trackJson;
         if (!m_discreteTracks.empty()) {
-            nlohmann::json discreteJson;
+            nlohmann::json discreteJson = nlohmann::json::array();
             for (auto&& [target, track] : m_discreteTracks) {
                 discreteJson.push_back(track);
             }
@@ -178,8 +181,8 @@ namespace moth_ui {
             }
         }
 
+        m_discreteTracks.clear();
         if (json.contains("discrete_tracks")) {
-            m_discreteTracks.clear();
             for (auto const& trackJson : json["discrete_tracks"]) {
                 DiscreteAnimationTrack track(AnimationTrack::Target::Unknown);
                 from_json(trackJson, track);

--- a/src/layout/layout_entity_flipbook.cpp
+++ b/src/layout/layout_entity_flipbook.cpp
@@ -5,8 +5,13 @@
 
 namespace moth_ui {
     namespace {
+        constexpr std::array<AnimationTrack::Target, 2> kFlipbookDiscreteTargets{
+            AnimationTrack::Target::FlipbookClip,
+            AnimationTrack::Target::FlipbookPlaying,
+        };
+
         void InitDiscreteFlipbookTracks(LayoutEntity& entity, bool seedFrame0) {
-            for (auto target : AnimationTrack::DiscreteTargets) {
+            for (auto target : kFlipbookDiscreteTargets) {
                 if (entity.m_discreteTracks.find(target) == entity.m_discreteTracks.end()) {
                     auto [it, ok] = entity.m_discreteTracks.emplace(target, DiscreteAnimationTrack(target));
                     if (seedFrame0) {

--- a/src/layout/layout_entity_flipbook.cpp
+++ b/src/layout/layout_entity_flipbook.cpp
@@ -1,18 +1,40 @@
 #include "moth_ui/layout/layout_entity_flipbook.h"
+#include "moth_ui/animation/discrete_animation_track.h"
+#include "moth_ui/animation/animation_track.h"
 #include "moth_ui/nodes/node_flipbook.h"
 
 namespace moth_ui {
+    namespace {
+        void InitDiscreteFlipbookTracks(LayoutEntity& entity, bool seedFrame0) {
+            for (auto target : AnimationTrack::DiscreteTargets) {
+                if (entity.m_discreteTracks.find(target) == entity.m_discreteTracks.end()) {
+                    auto [it, ok] = entity.m_discreteTracks.emplace(target, DiscreteAnimationTrack(target));
+                    if (seedFrame0) {
+                        std::string defaultValue;
+                        if (target == AnimationTrack::Target::FlipbookPlaying) {
+                            defaultValue = "0";
+                        }
+                        it->second.GetOrCreateKeyframe(0) = std::move(defaultValue);
+                    }
+                }
+            }
+        }
+    }
+
     LayoutEntityFlipbook::LayoutEntityFlipbook(LayoutRect const& initialBounds)
         : LayoutEntity(initialBounds) {
+        InitDiscreteFlipbookTracks(*this, true);
     }
 
     LayoutEntityFlipbook::LayoutEntityFlipbook(LayoutEntityGroup* parent)
         : LayoutEntity(parent) {
+        InitDiscreteFlipbookTracks(*this, true);
     }
 
     LayoutEntityFlipbook::LayoutEntityFlipbook(LayoutRect const& initialBounds, std::filesystem::path const& flipbookPath)
         : LayoutEntity(initialBounds)
         , m_flipbookPath(flipbookPath) {
+        InitDiscreteFlipbookTracks(*this, true);
     }
 
     std::shared_ptr<LayoutEntity> LayoutEntityFlipbook::Clone(CloneType cloneType) {
@@ -32,8 +54,6 @@ namespace moth_ui {
             auto const relativePath = std::filesystem::relative(m_flipbookPath, context.m_rootPath);
             j["flipbook_path"] = relativePath.string();
         }
-        j["clip_name"] = m_clipName;
-        j["autoplay"] = m_autoplay;
         return j;
     }
 
@@ -47,8 +67,22 @@ namespace moth_ui {
             } else {
                 m_flipbookPath = std::filesystem::absolute(context.m_rootPath / relativePath);
             }
-            m_clipName = json.value("clip_name", "");
-            m_autoplay = json.value("autoplay", false);
+            // Migrate legacy fields into discrete tracks (only if the track has no keyframes yet).
+            std::string legacyClipName = json.value("clip_name", "");
+            bool legacyAutoplay = json.value("autoplay", false);
+            InitDiscreteFlipbookTracks(*this, false);
+            if (!legacyClipName.empty()) {
+                auto& clipTrack = m_discreteTracks.at(AnimationTrack::Target::FlipbookClip);
+                if (clipTrack.Keyframes().empty()) {
+                    clipTrack.GetOrCreateKeyframe(0) = legacyClipName;
+                }
+            }
+            if (legacyAutoplay) {
+                auto& playingTrack = m_discreteTracks.at(AnimationTrack::Target::FlipbookPlaying);
+                if (playingTrack.Keyframes().empty()) {
+                    playingTrack.GetOrCreateKeyframe(0) = "1";
+                }
+            }
         }
 
         return success;

--- a/src/layout/layout_entity_flipbook.cpp
+++ b/src/layout/layout_entity_flipbook.cpp
@@ -10,6 +10,11 @@ namespace moth_ui {
         : LayoutEntity(parent) {
     }
 
+    LayoutEntityFlipbook::LayoutEntityFlipbook(LayoutRect const& initialBounds, std::filesystem::path const& flipbookPath)
+        : LayoutEntity(initialBounds)
+        , m_flipbookPath(flipbookPath) {
+    }
+
     std::shared_ptr<LayoutEntity> LayoutEntityFlipbook::Clone(CloneType cloneType) {
         return std::make_shared<LayoutEntityFlipbook>(*this);
     }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -121,6 +121,7 @@ namespace moth_ui {
         m_layoutRect = m_layout->GetBoundsAtFrame(frame);
         m_color = m_layout->GetColorAtFrame(frame);
         m_rotation = m_layout->GetRotationAtFrame(frame);
+        m_animationController->SetFrameDiscrete(frame);
         RecalculateBounds();
     }
 

--- a/src/nodes/node_flipbook.cpp
+++ b/src/nodes/node_flipbook.cpp
@@ -1,5 +1,7 @@
 #include "common.h"
 #include "moth_ui/nodes/node_flipbook.h"
+#include "moth_ui/animation/animation_controller.h"
+#include "moth_ui/animation/animation_track.h"
 #include "moth_ui/events/event_flipbook.h"
 #include "moth_ui/graphics/image_scale_type.h"
 #include "moth_ui/layout/layout_entity_flipbook.h"
@@ -43,10 +45,7 @@ namespace moth_ui {
                     m_flipbook.reset();
                     return;
                 }
-                SetClip(m_initialClipName);
-                if (m_autoplay) {
-                    SetPlaying(true);
-                }
+                // Initial clip and playing state are driven by discrete track callbacks.
             }
         }
     }
@@ -58,9 +57,18 @@ namespace moth_ui {
 
     void NodeFlipbook::ReloadEntityPrivate() {
         auto const layoutEntity = std::static_pointer_cast<LayoutEntityFlipbook>(m_layout);
-        m_initialClipName = layoutEntity->m_clipName;
-        m_autoplay = layoutEntity->m_autoplay;
         Load(layoutEntity->m_flipbookPath);
+
+        auto& controller = GetAnimationController();
+        controller.ClearDiscreteCallbacks();
+        controller.RegisterDiscreteCallback(AnimationTrack::Target::FlipbookClip, [this](std::string_view value) {
+            SetClip(value);
+        });
+        controller.RegisterDiscreteCallback(AnimationTrack::Target::FlipbookPlaying, [this](std::string_view value) {
+            SetPlaying(value == "1");
+        });
+        // Apply initial state from discrete tracks at frame 0.
+        controller.SetFrameDiscrete(0.0f);
     }
 
     void NodeFlipbook::SetClip(std::string_view name) {

--- a/src/nodes/node_flipbook.cpp
+++ b/src/nodes/node_flipbook.cpp
@@ -85,13 +85,22 @@ namespace moth_ui {
             bool wasPlaying = m_playing;
             m_playing = playing;
             if (!wasPlaying && m_playing) {
-                SendEventUp(EventFlipbookStarted(SharedFromThis(), m_currentClipName));
+                if (weak_from_this().expired()) {
+                    m_pendingStartedEvent = true;
+                } else {
+                    SendEventUp(EventFlipbookStarted(SharedFromThis(), m_currentClipName));
+                }
             }
         }
     }
 
     void NodeFlipbook::Update(uint32_t ticks) {
         Node::Update(ticks);
+
+        if (m_pendingStartedEvent) {
+            m_pendingStartedEvent = false;
+            SendEventUp(EventFlipbookStarted(SharedFromThis(), m_currentClipName));
+        }
 
         if (!m_playing || !m_flipbook || !m_currentClip.has_value()) {
             return;

--- a/src/nodes/node_flipbook.cpp
+++ b/src/nodes/node_flipbook.cpp
@@ -28,6 +28,8 @@ namespace moth_ui {
         m_sheetDesc.reset();
         m_flipbook.reset();
         m_playing = false;
+        m_pendingStartedEvent = false;
+        m_pendingStartedClipName.clear();
         auto* factory = m_context.GetFlipbookFactory();
         if (factory != nullptr) {
             m_flipbook = factory->GetFlipbook(path);
@@ -76,6 +78,8 @@ namespace moth_ui {
         m_currentFrame = 0;
         m_currentClip.reset();
         m_currentClipName.clear();
+        m_pendingStartedEvent = false;
+        m_pendingStartedClipName.clear();
         if (m_flipbook != nullptr) {
             IFlipbook::ClipDesc clipDesc;
             if (m_flipbook->GetClipDesc(name, clipDesc)) {
@@ -95,6 +99,7 @@ namespace moth_ui {
             if (!wasPlaying && m_playing) {
                 if (weak_from_this().expired()) {
                     m_pendingStartedEvent = true;
+                    m_pendingStartedClipName = m_currentClipName;
                 } else {
                     SendEventUp(EventFlipbookStarted(SharedFromThis(), m_currentClipName));
                 }
@@ -107,7 +112,8 @@ namespace moth_ui {
 
         if (m_pendingStartedEvent) {
             m_pendingStartedEvent = false;
-            SendEventUp(EventFlipbookStarted(SharedFromThis(), m_currentClipName));
+            SendEventUp(EventFlipbookStarted(SharedFromThis(), m_pendingStartedClipName));
+            m_pendingStartedClipName.clear();
         }
 
         if (!m_playing || !m_flipbook || !m_currentClip.has_value()) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,8 @@ set(SOURCES
     src/test_animation_clip_controller.cpp
     src/test_transform.cpp
     src/test_node_flipbook.cpp
+    src/test_discrete_animation_track.cpp
+    src/test_discrete_animation_track_controller.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/tests/src/test_animation_track.cpp
+++ b/tests/src/test_animation_track.cpp
@@ -182,6 +182,16 @@ TEST_CASE("AnimationTrack ForKeyframesOverFrames visits correct keyframes", "[an
     REQUIRE(visited[1] == 10);
 }
 
+TEST_CASE("AnimationTrack DiscreteTargets has 2 entries", "[animation_track][discrete]") {
+    REQUIRE(AnimationTrack::DiscreteTargets.size() == 2);
+}
+
+TEST_CASE("AnimationTrack DiscreteTargets contains FlipbookClip and FlipbookPlaying", "[animation_track][discrete]") {
+    auto const& dt = AnimationTrack::DiscreteTargets;
+    REQUIRE(dt[0] == AnimationTrack::Target::FlipbookClip);
+    REQUIRE(dt[1] == AnimationTrack::Target::FlipbookPlaying);
+}
+
 TEST_CASE("AnimationTrack copy construction deep-copies keyframes", "[animation_track][copy]") {
     AnimationTrack original(AnimationTrack::Target::TopOffset);
     original.GetOrCreateKeyframe(0).m_value = 7.0f;

--- a/tests/src/test_discrete_animation_track.cpp
+++ b/tests/src/test_discrete_animation_track.cpp
@@ -1,0 +1,145 @@
+#include "moth_ui/animation/animation_track.h"
+#include "moth_ui/animation/discrete_animation_track.h"
+#include <catch2/catch_all.hpp>
+#include <nlohmann/json.hpp>
+
+using namespace moth_ui;
+
+TEST_CASE("DiscreteAnimationTrack construction sets target and has no keyframes", "[discrete_track]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    REQUIRE(track.GetTarget() == AnimationTrack::Target::FlipbookClip);
+    REQUIRE(track.Keyframes().empty());
+}
+
+TEST_CASE("DiscreteAnimationTrack GetValueAtFrame returns empty with no keyframes", "[discrete_track][value]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    REQUIRE(track.GetValueAtFrame(0).empty());
+    REQUIRE(track.GetValueAtFrame(10).empty());
+}
+
+TEST_CASE("DiscreteAnimationTrack GetValueAtFrame returns last value at or before frame", "[discrete_track][value]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(0) = "idle";
+    track.GetOrCreateKeyframe(10) = "run";
+
+    REQUIRE(track.GetValueAtFrame(0) == "idle");
+    REQUIRE(track.GetValueAtFrame(5) == "idle");
+    REQUIRE(track.GetValueAtFrame(9) == "idle");
+    REQUIRE(track.GetValueAtFrame(10) == "run");
+    REQUIRE(track.GetValueAtFrame(99) == "run");
+}
+
+TEST_CASE("DiscreteAnimationTrack GetValueAtFrame returns empty before first keyframe", "[discrete_track][value]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(5) = "idle";
+
+    REQUIRE(track.GetValueAtFrame(0).empty());
+    REQUIRE(track.GetValueAtFrame(4).empty());
+    REQUIRE(track.GetValueAtFrame(5) == "idle");
+}
+
+TEST_CASE("DiscreteAnimationTrack GetOrCreateKeyframe inserts sorted", "[discrete_track][keyframes]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(10) = "c";
+    track.GetOrCreateKeyframe(0) = "a";
+    track.GetOrCreateKeyframe(5) = "b";
+
+    auto const& kfs = track.Keyframes();
+    REQUIRE(kfs.size() == 3);
+    REQUIRE(kfs[0].first == 0);
+    REQUIRE(kfs[1].first == 5);
+    REQUIRE(kfs[2].first == 10);
+}
+
+TEST_CASE("DiscreteAnimationTrack GetOrCreateKeyframe returns existing keyframe", "[discrete_track][keyframes]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(5) = "idle";
+
+    REQUIRE(track.Keyframes().size() == 1);
+    track.GetOrCreateKeyframe(5) = "run";
+    REQUIRE(track.Keyframes().size() == 1);
+    REQUIRE(track.GetValueAtFrame(5) == "run");
+}
+
+TEST_CASE("DiscreteAnimationTrack GetKeyframe finds by frame number", "[discrete_track][keyframes]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(3) = "hit";
+
+    auto* v = track.GetKeyframe(3);
+    REQUIRE(v != nullptr);
+    REQUIRE(*v == "hit");
+}
+
+TEST_CASE("DiscreteAnimationTrack GetKeyframe returns null for missing frame", "[discrete_track][keyframes]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(3) = "hit";
+
+    REQUIRE(track.GetKeyframe(99) == nullptr);
+}
+
+TEST_CASE("DiscreteAnimationTrack DeleteKeyframe removes the entry", "[discrete_track][keyframes]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(0) = "a";
+    track.GetOrCreateKeyframe(5) = "b";
+    REQUIRE(track.Keyframes().size() == 2);
+
+    track.DeleteKeyframe(0);
+    REQUIRE(track.Keyframes().size() == 1);
+    REQUIRE(track.GetKeyframe(0) == nullptr);
+    REQUIRE(track.GetKeyframe(5) != nullptr);
+}
+
+TEST_CASE("DiscreteAnimationTrack DeleteKeyframe on nonexistent frame is a no-op", "[discrete_track][keyframes]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(0) = "a";
+
+    track.DeleteKeyframe(99);
+    REQUIRE(track.Keyframes().size() == 1);
+}
+
+TEST_CASE("DiscreteAnimationTrack SortKeyframes reorders by ascending frame", "[discrete_track][sort]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.Keyframes().push_back({ 10, "c" });
+    track.Keyframes().push_back({ 0,  "a" });
+    track.Keyframes().push_back({ 5,  "b" });
+
+    track.SortKeyframes();
+
+    auto const& kfs = track.Keyframes();
+    REQUIRE(kfs[0].first == 0);
+    REQUIRE(kfs[1].first == 5);
+    REQUIRE(kfs[2].first == 10);
+    REQUIRE(kfs[0].second == "a");
+    REQUIRE(kfs[1].second == "b");
+    REQUIRE(kfs[2].second == "c");
+}
+
+TEST_CASE("DiscreteAnimationTrack to_json/from_json roundtrip", "[discrete_track][serialization]") {
+    DiscreteAnimationTrack original(AnimationTrack::Target::FlipbookClip);
+    original.GetOrCreateKeyframe(0) = "idle";
+    original.GetOrCreateKeyframe(10) = "run";
+
+    nlohmann::json j;
+    to_json(j, original);
+
+    DiscreteAnimationTrack deserialized(AnimationTrack::Target::Unknown);
+    from_json(j, deserialized);
+
+    REQUIRE(deserialized.GetTarget() == AnimationTrack::Target::FlipbookClip);
+    REQUIRE(deserialized.Keyframes().size() == 2);
+    REQUIRE(deserialized.GetValueAtFrame(0) == "idle");
+    REQUIRE(deserialized.GetValueAtFrame(10) == "run");
+}
+
+TEST_CASE("DiscreteAnimationTrack to_json/from_json preserves empty track", "[discrete_track][serialization]") {
+    DiscreteAnimationTrack original(AnimationTrack::Target::FlipbookPlaying);
+
+    nlohmann::json j;
+    to_json(j, original);
+
+    DiscreteAnimationTrack deserialized(AnimationTrack::Target::Unknown);
+    from_json(j, deserialized);
+
+    REQUIRE(deserialized.GetTarget() == AnimationTrack::Target::FlipbookPlaying);
+    REQUIRE(deserialized.Keyframes().empty());
+}

--- a/tests/src/test_discrete_animation_track_controller.cpp
+++ b/tests/src/test_discrete_animation_track_controller.cpp
@@ -1,0 +1,105 @@
+#include "moth_ui/animation/animation_track.h"
+#include "moth_ui/animation/discrete_animation_track.h"
+#include "moth_ui/animation/discrete_animation_track_controller.h"
+#include <catch2/catch_all.hpp>
+#include <string>
+#include <vector>
+
+using namespace moth_ui;
+
+TEST_CASE("DiscreteAnimationTrackController fires callback on first SetFrame", "[discrete_controller]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(0) = "idle";
+
+    std::vector<std::string> calls;
+    DiscreteAnimationTrackController ctrl(track, [&](std::string_view v) {
+        calls.push_back(std::string(v));
+    });
+
+    ctrl.SetFrame(0.0f);
+    REQUIRE(calls.size() == 1);
+    REQUIRE(calls[0] == "idle");
+}
+
+TEST_CASE("DiscreteAnimationTrackController fires callback on value change", "[discrete_controller]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(0) = "idle";
+    track.GetOrCreateKeyframe(10) = "run";
+
+    std::vector<std::string> calls;
+    DiscreteAnimationTrackController ctrl(track, [&](std::string_view v) {
+        calls.push_back(std::string(v));
+    });
+
+    ctrl.SetFrame(0.0f);  // fires "idle"
+    ctrl.SetFrame(5.0f);  // same value — no fire
+    ctrl.SetFrame(10.0f); // fires "run"
+
+    REQUIRE(calls.size() == 2);
+    REQUIRE(calls[0] == "idle");
+    REQUIRE(calls[1] == "run");
+}
+
+TEST_CASE("DiscreteAnimationTrackController does not re-fire on unchanged value", "[discrete_controller]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(0) = "idle";
+
+    int count = 0;
+    DiscreteAnimationTrackController ctrl(track, [&](std::string_view) { ++count; });
+
+    ctrl.SetFrame(0.0f);
+    ctrl.SetFrame(1.0f);
+    ctrl.SetFrame(2.0f);
+    REQUIRE(count == 1);
+}
+
+TEST_CASE("DiscreteAnimationTrackController Reset forces re-fire on next SetFrame", "[discrete_controller]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(0) = "idle";
+
+    int count = 0;
+    DiscreteAnimationTrackController ctrl(track, [&](std::string_view) { ++count; });
+
+    ctrl.SetFrame(0.0f);
+    REQUIRE(count == 1);
+
+    ctrl.Reset();
+    ctrl.SetFrame(0.0f); // same value, but Reset() cleared initialized flag
+    REQUIRE(count == 2);
+}
+
+TEST_CASE("DiscreteAnimationTrackController fires empty string before first keyframe", "[discrete_controller]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(10) = "idle";
+
+    std::vector<std::string> calls;
+    DiscreteAnimationTrackController ctrl(track, [&](std::string_view v) {
+        calls.push_back(std::string(v));
+    });
+
+    ctrl.SetFrame(0.0f);  // before first keyframe — empty string
+    REQUIRE(calls.size() == 1);
+    REQUIRE(calls[0].empty());
+
+    ctrl.SetFrame(10.0f); // reaches keyframe — fires "idle"
+    REQUIRE(calls.size() == 2);
+    REQUIRE(calls[1] == "idle");
+}
+
+TEST_CASE("DiscreteAnimationTrackController handles backward scrub with value change", "[discrete_controller]") {
+    DiscreteAnimationTrack track(AnimationTrack::Target::FlipbookClip);
+    track.GetOrCreateKeyframe(0) = "idle";
+    track.GetOrCreateKeyframe(10) = "run";
+
+    std::vector<std::string> calls;
+    DiscreteAnimationTrackController ctrl(track, [&](std::string_view v) {
+        calls.push_back(std::string(v));
+    });
+
+    ctrl.SetFrame(10.0f); // fires "run" (first call)
+    ctrl.SetFrame(0.0f);  // fires "idle" (changed)
+
+    REQUIRE(calls.size() == 2);
+    REQUIRE(calls[0] == "run");
+    REQUIRE(calls[1] == "idle");
+}

--- a/tests/src/test_node_flipbook.cpp
+++ b/tests/src/test_node_flipbook.cpp
@@ -1,8 +1,11 @@
 #include "mock_context.h"
+#include "moth_ui/animation/animation_track.h"
 #include "moth_ui/events/event_flipbook.h"
 #include "moth_ui/graphics/iflipbook.h"
 #include "moth_ui/graphics/iimage.h"
 #include "moth_ui/iflipbook_factory.h"
+#include "moth_ui/layout/layout_entity_flipbook.h"
+#include "moth_ui/layout/layout_rect.h"
 #include "moth_ui/nodes/group.h"
 #include "moth_ui/nodes/node_flipbook.h"
 #include <catch2/catch_all.hpp>
@@ -104,8 +107,8 @@ TEST_CASE("Load with null factory clears all flipbook state", "[flipbook][load]"
     MockFlipbook fb = MakeSimpleFlipbook();
     tc.flipbookFactory.nextFlipbook = &fb;
     auto primed = std::make_shared<NodeFlipbook>(tc.context);
-    primed->SetInitialClipName("run");
     primed->Load("dummy.flipbook.json");
+    primed->SetClip("run");
     REQUIRE(primed->GetFlipbook() != nullptr);
 
     // Now call Load on a node whose context has no factory.
@@ -120,7 +123,6 @@ TEST_CASE("Load with factory returning null clears all flipbook state", "[flipbo
     FlipbookTestContext tc;
     // nextFlipbook is null — factory returns nullptr.
     auto node = std::make_shared<NodeFlipbook>(tc.context);
-    node->SetInitialClipName("run");
     node->Load("nonexistent.flipbook.json");
 
     REQUIRE(node->GetFlipbook() == nullptr);
@@ -135,8 +137,8 @@ TEST_CASE("Load clears previous flipbook when factory returns null", "[flipbook]
     tc.flipbookFactory.nextFlipbook = &fb;
 
     auto node = std::make_shared<NodeFlipbook>(tc.context);
-    node->SetInitialClipName("run");
     node->Load("dummy.flipbook.json");
+    node->SetClip("run");
     REQUIRE(node->GetFlipbook() != nullptr);
 
     // Now make the factory return null and reload.
@@ -205,8 +207,8 @@ TEST_CASE("Load resets playback state before loading", "[flipbook][load]") {
     tc.flipbookFactory.nextFlipbook = &fb;
 
     auto node = std::make_shared<NodeFlipbook>(tc.context);
-    node->SetInitialClipName("run");
     node->Load("dummy.flipbook.json");
+    node->SetClip("run");
     node->SetPlaying(true);
     node->Update(84); // advance one frame
 
@@ -218,68 +220,77 @@ TEST_CASE("Load resets playback state before loading", "[flipbook][load]") {
     REQUIRE_FALSE(node->IsPlaying());
 }
 
-TEST_CASE("Load with initial clip name activates that clip", "[flipbook][load]") {
+TEST_CASE("SetClip after Load activates the named clip", "[flipbook][load]") {
     FlipbookTestContext tc;
     MockFlipbook fb = MakeSimpleFlipbook();
     tc.flipbookFactory.nextFlipbook = &fb;
 
     auto node = std::make_shared<NodeFlipbook>(tc.context);
-    node->SetInitialClipName("run");
     node->Load("dummy.flipbook.json");
+    node->SetClip("run");
 
     REQUIRE(node->GetCurrentClipName() == "run");
     REQUIRE(node->GetCurrentFrame() == 0); // Start of clip
 }
 
-TEST_CASE("Load with no initial clip name leaves clip unset", "[flipbook][load]") {
+TEST_CASE("Load with no clip set leaves clip unset", "[flipbook][load]") {
     FlipbookTestContext tc;
     MockFlipbook fb = MakeSimpleFlipbook();
     tc.flipbookFactory.nextFlipbook = &fb;
 
     auto node = std::make_shared<NodeFlipbook>(tc.context);
-    // m_initialClipName defaults to empty
     node->Load("dummy.flipbook.json");
+    // No SetClip call — clip stays empty.
 
     REQUIRE(node->GetCurrentClipName().empty());
     REQUIRE_FALSE(node->IsPlaying());
 }
 
-TEST_CASE("Autoplay true starts playback after Load", "[flipbook][load][autoplay]") {
+TEST_CASE("Discrete track FlipbookPlaying=1 at frame 0 starts playback on instantiate", "[flipbook][load][discrete]") {
+    // Autoplay is now expressed via the FlipbookPlaying discrete track on the layout entity.
     FlipbookTestContext tc;
     MockFlipbook fb = MakeSimpleFlipbook();
     tc.flipbookFactory.nextFlipbook = &fb;
 
-    auto node = std::make_shared<NodeFlipbook>(tc.context);
-    node->SetInitialClipName("run");
-    node->SetAutoplay(true);
-    node->Load("dummy.flipbook.json");
+    auto entity = std::make_shared<LayoutEntityFlipbook>(MakeDefaultLayoutRect(), "dummy.flipbook.json");
+    entity->m_discreteTracks.at(AnimationTrack::Target::FlipbookClip).GetOrCreateKeyframe(0) = "run";
+    entity->m_discreteTracks.at(AnimationTrack::Target::FlipbookPlaying).GetOrCreateKeyframe(0) = "1";
+
+    auto nodeBase = entity->Instantiate(tc.context);
+    auto* node = static_cast<NodeFlipbook*>(nodeBase.get());
 
     REQUIRE(node->IsPlaying());
+    REQUIRE(node->GetCurrentClipName() == "run");
 }
 
-TEST_CASE("Autoplay false does not start playback after Load", "[flipbook][load][autoplay]") {
+TEST_CASE("Discrete track FlipbookPlaying=0 at frame 0 does not start playback on instantiate", "[flipbook][load][discrete]") {
     FlipbookTestContext tc;
     MockFlipbook fb = MakeSimpleFlipbook();
     tc.flipbookFactory.nextFlipbook = &fb;
 
-    auto node = std::make_shared<NodeFlipbook>(tc.context);
-    node->SetInitialClipName("run");
-    node->SetAutoplay(false);
-    node->Load("dummy.flipbook.json");
+    auto entity = std::make_shared<LayoutEntityFlipbook>(MakeDefaultLayoutRect(), "dummy.flipbook.json");
+    entity->m_discreteTracks.at(AnimationTrack::Target::FlipbookClip).GetOrCreateKeyframe(0) = "run";
+    // FlipbookPlaying defaults to "0" at frame 0 from InitDiscreteFlipbookTracks.
+
+    auto nodeBase = entity->Instantiate(tc.context);
+    auto* node = static_cast<NodeFlipbook*>(nodeBase.get());
 
     REQUIRE_FALSE(node->IsPlaying());
+    REQUIRE(node->GetCurrentClipName() == "run");
 }
 
-TEST_CASE("Autoplay true with no initial clip does not start playback", "[flipbook][load][autoplay]") {
-    // Autoplay requires a clip to be set — no clip means SetPlaying is a no-op.
+TEST_CASE("Discrete track FlipbookPlaying=1 with no clip does not start playback", "[flipbook][load][discrete]") {
+    // SetPlaying requires a clip — FlipbookPlaying=1 with no clip is a no-op.
     FlipbookTestContext tc;
     MockFlipbook fb = MakeSimpleFlipbook();
     tc.flipbookFactory.nextFlipbook = &fb;
 
-    auto node = std::make_shared<NodeFlipbook>(tc.context);
-    node->SetAutoplay(true);
-    // No SetInitialClipName — m_initialClipName is empty.
-    node->Load("dummy.flipbook.json");
+    auto entity = std::make_shared<LayoutEntityFlipbook>(MakeDefaultLayoutRect(), "dummy.flipbook.json");
+    entity->m_discreteTracks.at(AnimationTrack::Target::FlipbookPlaying).GetOrCreateKeyframe(0) = "1";
+    // No clip name set in FlipbookClip track.
+
+    auto nodeBase = entity->Instantiate(tc.context);
+    auto* node = static_cast<NodeFlipbook*>(nodeBase.get());
 
     REQUIRE_FALSE(node->IsPlaying());
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added discrete animation tracks and controllers for step-based string/state animation (FlipbookClip, FlipbookPlaying) and new animation-controller APIs to register/clear callbacks and evaluate discrete frames.

* **Refactor**
  * Flipbook entities now derive initial clip/playing state from discrete tracks; legacy clip/autoplay settings are migrated into tracks and removed from public config.

* **Tests**
  * Added unit tests covering discrete tracks, their controllers, and updated flipbook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->