### PR TITLE
Add per-node TextureFilter support to IRenderer and layout entities

### DIFF
--- a/include/moth_ui/graphics/irenderer.h
+++ b/include/moth_ui/graphics/irenderer.h
@@ -4,6 +4,7 @@
 #include "moth_ui/graphics/blend_mode.h"
 #include "moth_ui/graphics/image_scale_type.h"
 #include "moth_ui/graphics/text_alignment.h"
+#include "moth_ui/graphics/texture_filter.h"
 #include "moth_ui/utils/color.h"
 #include "moth_ui/utils/rect.h"
 #include "moth_ui/utils/transform.h"
@@ -57,6 +58,18 @@ namespace moth_ui {
 
         /// @brief Pops the top clip rectangle, restoring the previous clip region.
         virtual void PopClip() = 0;
+
+        /**
+         * @brief Pushes a texture sampling filter onto the filter stack.
+         *
+         * Affects subsequent @c RenderImage calls until the matching @c PopTextureFilter.
+         * The default (bottom of stack) is @c TextureFilter::Linear.
+         * @param filter The filter to apply.
+         */
+        virtual void PushTextureFilter(TextureFilter filter) = 0;
+
+        /// @brief Pops the top texture filter, restoring the previous one.
+        virtual void PopTextureFilter() = 0;
 
         /**
          * @brief Draws the outline of a rectangle using the current colour.

--- a/include/moth_ui/graphics/texture_filter.h
+++ b/include/moth_ui/graphics/texture_filter.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace moth_ui {
+    /**
+     * @brief Selects the texture sampling filter applied when an image is
+     *        scaled up or down during rendering.
+     */
+    enum class TextureFilter {
+        Invalid = -1, ///< Sentinel value indicating an unset filter.
+        Linear,       ///< Bilinear interpolation — smooth, suitable for photos and gradients.
+        Nearest,      ///< Nearest-neighbour — crisp, suitable for pixel art and icons.
+    };
+}

--- a/include/moth_ui/layout/layout_entity_flipbook.h
+++ b/include/moth_ui/layout/layout_entity_flipbook.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "moth_ui/graphics/texture_filter.h"
 #include "moth_ui/layout/layout_entity.h"
 
 namespace moth_ui {
@@ -26,6 +27,7 @@ namespace moth_ui {
         nlohmann::json Serialize(SerializeContext const& context) const override;
         bool Deserialize(nlohmann::json const& json, SerializeContext const& context) override;
 
-        std::filesystem::path m_flipbookPath; ///< Path to the .flipbook.json descriptor file.
+        std::filesystem::path m_flipbookPath;                  ///< Path to the .flipbook.json descriptor file.
+        TextureFilter m_textureFilter = TextureFilter::Linear; ///< Sampling filter applied when the flipbook is scaled.
     };
 }

--- a/include/moth_ui/layout/layout_entity_image.h
+++ b/include/moth_ui/layout/layout_entity_image.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "moth_ui/graphics/image_scale_type.h"
+#include "moth_ui/graphics/texture_filter.h"
 #include "moth_ui/layout/layout_entity.h"
 #include "moth_ui/layout/layout_rect.h"
 #include "moth_ui/utils/rect.h"
@@ -49,6 +50,7 @@ namespace moth_ui {
         IntRect m_sourceRect;                                 ///< Portion of the image to display.
         ImageScaleType m_imageScaleType = ImageScaleType::Stretch; ///< How the image is scaled.
         float m_imageScale = 1.0f;                            ///< Uniform scale factor for tile/nine-slice modes.
+        TextureFilter m_textureFilter = TextureFilter::Linear; ///< Sampling filter applied when the image is scaled.
 
         // 9slice only
         static int constexpr DefaultBorderSize = 15;                                               ///< Default nine-slice border width in pixels.

--- a/include/moth_ui/moth_ui.h
+++ b/include/moth_ui/moth_ui.h
@@ -30,6 +30,7 @@
 #include "moth_ui/graphics/irenderer.h"
 #include "moth_ui/graphics/itarget.h"
 #include "moth_ui/graphics/text_alignment.h"
+#include "moth_ui/graphics/texture_filter.h"
 #include "moth_ui/graphics/iflipbook.h"
 
 // layout

--- a/include/moth_ui/nodes/node_flipbook.h
+++ b/include/moth_ui/nodes/node_flipbook.h
@@ -99,7 +99,7 @@ namespace moth_ui {
          * @param filter @c TextureFilter::Linear for smooth scaling,
          *               @c TextureFilter::Nearest for crisp pixel art.
          */
-        void SetTextureFilter(TextureFilter filter) { m_textureFilter = filter; }
+        void SetTextureFilter(TextureFilter filter) { m_textureFilter = (filter == TextureFilter::Invalid) ? TextureFilter::Linear : filter; }
 
         void Update(uint32_t ticks) override;
 

--- a/include/moth_ui/nodes/node_flipbook.h
+++ b/include/moth_ui/nodes/node_flipbook.h
@@ -2,6 +2,7 @@
 
 #include "moth_ui/context.h"
 #include "moth_ui/graphics/iflipbook.h"
+#include "moth_ui/graphics/texture_filter.h"
 #include "moth_ui/nodes/node.h"
 #include <memory>
 #include <optional>
@@ -90,9 +91,20 @@ namespace moth_ui {
          */
         void SetClip(std::string_view name);
 
+        /// @brief Returns the texture sampling filter applied when the flipbook is scaled.
+        TextureFilter GetTextureFilter() const { return m_textureFilter; }
+
+        /**
+         * @brief Sets the texture sampling filter.
+         * @param filter @c TextureFilter::Linear for smooth scaling,
+         *               @c TextureFilter::Nearest for crisp pixel art.
+         */
+        void SetTextureFilter(TextureFilter filter) { m_textureFilter = filter; }
+
         void Update(uint32_t ticks) override;
 
     protected:
+        TextureFilter m_textureFilter = TextureFilter::Linear; ///< Sampling filter applied when the flipbook is scaled.
         std::unique_ptr<IFlipbook> m_flipbook;            ///< Loaded flipbook, or null if none is set.
         std::optional<IFlipbook::ClipDesc> m_currentClip; ///< Active clip, empty if no clip is set.
         std::string m_currentClipName;                    ///< Name of the active clip, or empty if none is set.

--- a/include/moth_ui/nodes/node_image.h
+++ b/include/moth_ui/nodes/node_image.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "moth_ui/graphics/image_scale_type.h"
+#include "moth_ui/graphics/texture_filter.h"
 #include "moth_ui/nodes/node.h"
 
 #include <array>
@@ -65,17 +66,28 @@ namespace moth_ui {
         /// @brief Returns the uniform scale factor used in tile/nine-slice modes.
         float GetImageScale() const { return m_imageScale; }
 
+        /// @brief Returns the texture sampling filter applied when the image is scaled.
+        TextureFilter GetTextureFilter() const { return m_textureFilter; }
+
         /**
          * @brief Sets the image scale type.
          * @param type Scale type to use when rendering.
          */
         void SetImageScaleType(ImageScaleType type) { m_imageScaleType = type; }
 
+        /**
+         * @brief Sets the texture sampling filter.
+         * @param filter @c TextureFilter::Linear for smooth scaling,
+         *               @c TextureFilter::Nearest for crisp pixel art.
+         */
+        void SetTextureFilter(TextureFilter filter) { m_textureFilter = filter; }
+
     protected:
         std::unique_ptr<IImage> m_image;
         IntRect m_sourceRect;
         ImageScaleType m_imageScaleType = ImageScaleType::Stretch;
         float m_imageScale = 1.0f;
+        TextureFilter m_textureFilter = TextureFilter::Linear;
 
         IntRect m_sourceBorders;
         LayoutRect m_targetBorders;

--- a/include/moth_ui/nodes/node_image.h
+++ b/include/moth_ui/nodes/node_image.h
@@ -80,7 +80,7 @@ namespace moth_ui {
          * @param filter @c TextureFilter::Linear for smooth scaling,
          *               @c TextureFilter::Nearest for crisp pixel art.
          */
-        void SetTextureFilter(TextureFilter filter) { m_textureFilter = filter; }
+        void SetTextureFilter(TextureFilter filter) { m_textureFilter = (filter == TextureFilter::Invalid) ? TextureFilter::Linear : filter; }
 
     protected:
         std::unique_ptr<IImage> m_image;

--- a/src/layout/layout_entity_flipbook.cpp
+++ b/src/layout/layout_entity_flipbook.cpp
@@ -1,3 +1,4 @@
+#include "moth_ui/graphics/texture_filter.h"
 #include "moth_ui/layout/layout_entity_flipbook.h"
 #include "moth_ui/animation/discrete_animation_track.h"
 #include "moth_ui/animation/animation_track.h"
@@ -59,6 +60,7 @@ namespace moth_ui {
             auto const relativePath = std::filesystem::relative(m_flipbookPath, context.m_rootPath);
             j["flipbook_path"] = relativePath.string();
         }
+        j["textureFilter"] = m_textureFilter;
         return j;
     }
 
@@ -72,6 +74,7 @@ namespace moth_ui {
             } else {
                 m_flipbookPath = std::filesystem::absolute(context.m_rootPath / relativePath);
             }
+            m_textureFilter = json.value("textureFilter", TextureFilter::Linear);
             // Migrate legacy fields into discrete tracks (only if the track has no keyframes yet).
             std::string legacyClipName = json.value("clip_name", "");
             bool legacyAutoplay = json.value("autoplay", false);

--- a/src/layout/layout_entity_flipbook.cpp
+++ b/src/layout/layout_entity_flipbook.cpp
@@ -74,7 +74,8 @@ namespace moth_ui {
             } else {
                 m_flipbookPath = std::filesystem::absolute(context.m_rootPath / relativePath);
             }
-            m_textureFilter = json.value("textureFilter", TextureFilter::Linear);
+            auto const rawFilter = json.value("textureFilter", TextureFilter::Linear);
+            m_textureFilter = (rawFilter == TextureFilter::Invalid) ? TextureFilter::Linear : rawFilter;
             // Migrate legacy fields into discrete tracks (only if the track has no keyframes yet).
             std::string legacyClipName = json.value("clip_name", "");
             bool legacyAutoplay = json.value("autoplay", false);

--- a/src/layout/layout_entity_image.cpp
+++ b/src/layout/layout_entity_image.cpp
@@ -1,4 +1,5 @@
 #include "common.h"
+#include "moth_ui/graphics/texture_filter.h"
 #include "moth_ui/layout/layout_entity_image.h"
 #include "moth_ui/nodes/node_image.h"
 
@@ -32,6 +33,7 @@ namespace moth_ui {
         j["sourceRect"] = m_sourceRect;
         j["imageScaleType"] = m_imageScaleType;
         j["imageScale"] = m_imageScale;
+        j["textureFilter"] = m_textureFilter;
         j["sourceBorders"] = m_sourceBorders;
         j["targetBorders"] = m_targetBorders;
         return j;
@@ -44,6 +46,7 @@ namespace moth_ui {
             m_sourceRect = json.value("sourceRect", IntRect{});
             m_imageScaleType = json.value("imageScaleType", ImageScaleType::Stretch);
             m_imageScale = json.value("imageScale", 1.0f);
+            m_textureFilter = json.value("textureFilter", TextureFilter::Linear);
             m_sourceBorders = json.value("sourceBorders", IntRect{});
             m_targetBorders = json.value("targetBorders", MakeDefaultLayoutRect());
             std::string relativePath = json.value("imagePath", "");

--- a/src/layout/layout_entity_image.cpp
+++ b/src/layout/layout_entity_image.cpp
@@ -46,7 +46,8 @@ namespace moth_ui {
             m_sourceRect = json.value("sourceRect", IntRect{});
             m_imageScaleType = json.value("imageScaleType", ImageScaleType::Stretch);
             m_imageScale = json.value("imageScale", 1.0f);
-            m_textureFilter = json.value("textureFilter", TextureFilter::Linear);
+            auto const rawFilter = json.value("textureFilter", TextureFilter::Linear);
+            m_textureFilter = (rawFilter == TextureFilter::Invalid) ? TextureFilter::Linear : rawFilter;
             m_sourceBorders = json.value("sourceBorders", IntRect{});
             m_targetBorders = json.value("targetBorders", MakeDefaultLayoutRect());
             std::string relativePath = json.value("imagePath", "");

--- a/src/nodes/node_flipbook.cpp
+++ b/src/nodes/node_flipbook.cpp
@@ -48,6 +48,7 @@ namespace moth_ui {
 
     void NodeFlipbook::ReloadEntityPrivate() {
         auto const layoutEntity = std::static_pointer_cast<LayoutEntityFlipbook>(m_layout);
+        m_textureFilter = layoutEntity->m_textureFilter;
         Load(layoutEntity->m_flipbookPath);
 
         auto& controller = GetAnimationController();
@@ -159,7 +160,9 @@ namespace moth_ui {
             { -frameDesc.pivot.x, -frameDesc.pivot.y },
             { frameDesc.rect.w() - frameDesc.pivot.x, frameDesc.rect.h() - frameDesc.pivot.y }
         };
+        renderer.PushTextureFilter(m_textureFilter);
         renderer.RenderImage(image, frameDesc.rect, destRect, ImageScaleType::Stretch, 1.0f);
+        renderer.PopTextureFilter();
     }
 
     std::shared_ptr<NodeFlipbook> NodeFlipbook::SharedFromThis() {

--- a/src/nodes/node_image.cpp
+++ b/src/nodes/node_image.cpp
@@ -39,6 +39,7 @@ namespace moth_ui {
     void NodeImage::DrawInternal() {
         if (m_image) {
             auto& renderer = m_context.GetRenderer();
+            renderer.PushTextureFilter(m_textureFilter);
             if (m_imageScaleType == ImageScaleType::NineSlice) {
                 for (int horizSliceIdx = 0; horizSliceIdx < 3; ++horizSliceIdx) {
                     for (int vertSliceIdx = 0; vertSliceIdx < 3; ++vertSliceIdx) {
@@ -59,6 +60,7 @@ namespace moth_ui {
                 IntRect const localRect{ { 0, 0 }, m_screenRect.bottomRight - m_screenRect.topLeft };
                 renderer.RenderImage(*m_image, m_sourceRect, localRect, m_imageScaleType, m_imageScale);
             }
+            renderer.PopTextureFilter();
         }
     }
 
@@ -82,6 +84,7 @@ namespace moth_ui {
         m_sourceRect = layoutEntity->m_sourceRect;
         m_imageScaleType = layoutEntity->m_imageScaleType;
         m_imageScale = layoutEntity->m_imageScale;
+        m_textureFilter = layoutEntity->m_textureFilter;
         m_sourceBorders = layoutEntity->m_sourceBorders;
         m_targetBorders = layoutEntity->m_targetBorders;
         Load(layoutEntity->m_imagePath);

--- a/tests/src/api_surface_graphics.cpp
+++ b/tests/src/api_surface_graphics.cpp
@@ -19,6 +19,8 @@ TEST_CASE("IRenderer method signatures are stable", "[api][graphics][irenderer]"
     void (IRenderer::*popXform)()                    = &IRenderer::PopTransform;
     void (IRenderer::*pushClip)(IntRect const&)      = &IRenderer::PushClip;
     void (IRenderer::*popClip)()                     = &IRenderer::PopClip;
+    void (IRenderer::*pushFilter)(TextureFilter)     = &IRenderer::PushTextureFilter;
+    void (IRenderer::*popFilter)()                   = &IRenderer::PopTextureFilter;
     // Draw calls
     void (IRenderer::*renderRect)(IntRect const&)        = &IRenderer::RenderRect;
     void (IRenderer::*renderFilled)(IntRect const&)      = &IRenderer::RenderFilledRect;
@@ -31,6 +33,7 @@ TEST_CASE("IRenderer method signatures are stable", "[api][graphics][irenderer]"
 
     (void)pushBlend; (void)popBlend; (void)pushColor; (void)popColor;
     (void)pushXform; (void)popXform; (void)pushClip;  (void)popClip;
+    (void)pushFilter; (void)popFilter;
     (void)renderRect; (void)renderFilled; (void)renderImg;
     (void)renderText; (void)setLogical;
     SUCCEED();
@@ -88,6 +91,13 @@ TEST_CASE("BlendMode enum values are stable", "[api][graphics][enums]") {
 TEST_CASE("ImageScaleType enum values are stable", "[api][graphics][enums]") {
     static_assert(ImageScaleType::Stretch   != ImageScaleType::Tile);
     static_assert(ImageScaleType::Tile      != ImageScaleType::NineSlice);
+    SUCCEED();
+}
+
+TEST_CASE("TextureFilter enum values are stable", "[api][graphics][enums]") {
+    static_assert(static_cast<int>(TextureFilter::Invalid) == -1);
+    static_assert(static_cast<int>(TextureFilter::Linear)  ==  0);
+    static_assert(static_cast<int>(TextureFilter::Nearest) ==  1);
     SUCCEED();
 }
 

--- a/tests/src/mock_context.h
+++ b/tests/src/mock_context.h
@@ -22,6 +22,8 @@ public:
     void PopTransform() override {}
     void PushClip(moth_ui::IntRect const&) override {}
     void PopClip() override {}
+    void PushTextureFilter(moth_ui::TextureFilter) override {}
+    void PopTextureFilter() override {}
     void RenderRect(moth_ui::IntRect const&) override {}
     void RenderFilledRect(moth_ui::IntRect const&) override {}
     void RenderImage(moth_ui::IImage const&, moth_ui::IntRect const&, moth_ui::IntRect const&, moth_ui::ImageScaleType, float) override {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable texture filtering for images and flipbooks. Users can now select between Linear (smooth interpolation) and Nearest (sharp pixel-perfect) sampling filters to control image appearance when scaled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->