### PR TITLE
refactor: remove EventDirection enum and SendEvent(direction) overload

### DIFF
--- a/include/moth_ui/nodes/node.h
+++ b/include/moth_ui/nodes/node.h
@@ -49,7 +49,7 @@ namespace moth_ui {
          * @param event Event to dispatch.
          * @return @c true if the event was handled.
          */
-        bool SendEventUp(Event const& event);
+        bool SendEvent(Event const& event);
 
         /**
          * @brief Broadcasts an event across the full subtree in depth-first order.

--- a/include/moth_ui/nodes/node.h
+++ b/include/moth_ui/nodes/node.h
@@ -44,20 +44,6 @@ namespace moth_ui {
          */
         static std::shared_ptr<Node> Create(Context& context, std::shared_ptr<LayoutEntity> layoutEntity);
 
-        /// @brief Direction in which an event travels through the scene graph.
-        enum class EventDirection {
-            Up,   ///< Event travels from child toward root.
-            Down, ///< Event travels from root toward leaves.
-        };
-
-        /**
-         * @brief Sends an event either up or down the scene graph.
-         * @param event     Event to dispatch.
-         * @param direction Travel direction.
-         * @return @c true if the event was handled.
-         */
-        bool SendEvent(Event const& event, EventDirection direction);
-
         /**
          * @brief Sends an event upward toward the root.
          * @param event Event to dispatch.

--- a/src/animation/animation_clip_controller.cpp
+++ b/src/animation/animation_clip_controller.cpp
@@ -19,7 +19,7 @@ namespace moth_ui {
             for (auto const& child : m_group->GetChildren()) {
                 child->GetAnimationController().SetFrame(m_frame);
             }
-            m_group->SendEvent(EventAnimationStarted(m_group->shared_from_this(), clip->name), Node::EventDirection::Up);
+            m_group->SendEventUp(EventAnimationStarted(m_group->shared_from_this(), clip->name));
         }
     }
 
@@ -75,7 +75,7 @@ namespace moth_ui {
             }
 
             if (animationEnded) {
-                m_group->SendEvent(EventAnimationStopped(m_group->shared_from_this(), animationName), Node::EventDirection::Up);
+                m_group->SendEventUp(EventAnimationStopped(m_group->shared_from_this(), animationName));
             }
         }
     }
@@ -87,7 +87,7 @@ namespace moth_ui {
         }
         for (auto& animEvent : layout->m_events) {
             if (static_cast<float>(animEvent->frame) > startFrame && static_cast<float>(animEvent->frame) <= endFrame) {
-                m_group->SendEvent(EventAnimation(m_group->shared_from_this(), animEvent->name), Node::EventDirection::Up);
+                m_group->SendEventUp(EventAnimation(m_group->shared_from_this(), animEvent->name));
             }
         }
     }

--- a/src/animation/animation_clip_controller.cpp
+++ b/src/animation/animation_clip_controller.cpp
@@ -19,7 +19,7 @@ namespace moth_ui {
             for (auto const& child : m_group->GetChildren()) {
                 child->GetAnimationController().SetFrame(m_frame);
             }
-            m_group->SendEventUp(EventAnimationStarted(m_group->shared_from_this(), clip->name));
+            m_group->SendEvent(EventAnimationStarted(m_group->shared_from_this(), clip->name));
         }
     }
 
@@ -75,7 +75,7 @@ namespace moth_ui {
             }
 
             if (animationEnded) {
-                m_group->SendEventUp(EventAnimationStopped(m_group->shared_from_this(), animationName));
+                m_group->SendEvent(EventAnimationStopped(m_group->shared_from_this(), animationName));
             }
         }
     }
@@ -87,7 +87,7 @@ namespace moth_ui {
         }
         for (auto& animEvent : layout->m_events) {
             if (static_cast<float>(animEvent->frame) > startFrame && static_cast<float>(animEvent->frame) <= endFrame) {
-                m_group->SendEventUp(EventAnimation(m_group->shared_from_this(), animEvent->name));
+                m_group->SendEvent(EventAnimation(m_group->shared_from_this(), animEvent->name));
             }
         }
     }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -19,7 +19,7 @@ namespace moth_ui {
         Node::ReloadEntityInternal();
     }
 
-    bool Node::SendEventUp(Event const& event) {
+    bool Node::SendEvent(Event const& event) {
         auto* currentNode = this;
         while (currentNode != nullptr) {
             if (currentNode->OnEvent(event)) {

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -19,17 +19,6 @@ namespace moth_ui {
         Node::ReloadEntityInternal();
     }
 
-    bool Node::SendEvent(Event const& event, EventDirection direction) {
-        if (direction == EventDirection::Up) {
-            return SendEventUp(event);
-        }
-        if (direction == EventDirection::Down) {
-            return Broadcast(event);
-        }
-        assert(false && "Bad event direction.");
-        return false;
-    }
-
     bool Node::SendEventUp(Event const& event) {
         auto* currentNode = this;
         while (currentNode != nullptr) {

--- a/src/nodes/node_flipbook.cpp
+++ b/src/nodes/node_flipbook.cpp
@@ -99,7 +99,7 @@ namespace moth_ui {
                     m_pendingStartedEvent = true;
                     m_pendingStartedClipName = m_currentClipName;
                 } else {
-                    SendEventUp(EventFlipbookStarted(SharedFromThis(), m_currentClipName));
+                    SendEvent(EventFlipbookStarted(SharedFromThis(), m_currentClipName));
                 }
             }
         }
@@ -110,7 +110,7 @@ namespace moth_ui {
 
         if (m_pendingStartedEvent) {
             m_pendingStartedEvent = false;
-            SendEventUp(EventFlipbookStarted(SharedFromThis(), m_pendingStartedClipName));
+            SendEvent(EventFlipbookStarted(SharedFromThis(), m_pendingStartedClipName));
             m_pendingStartedClipName.clear();
         }
 
@@ -137,13 +137,13 @@ namespace moth_ui {
                     m_accumulatedMs = 0;
                     m_currentFrame = 0;
                     m_playing = false;
-                    SendEventUp(EventFlipbookStopped(SharedFromThis(), m_currentClipName));
+                    SendEvent(EventFlipbookStopped(SharedFromThis(), m_currentClipName));
                     break;
                 case IFlipbook::LoopType::Stop:
                     m_accumulatedMs = 0;
                     m_currentFrame = lastStep;
                     m_playing = false;
-                    SendEventUp(EventFlipbookStopped(SharedFromThis(), m_currentClipName));
+                    SendEvent(EventFlipbookStopped(SharedFromThis(), m_currentClipName));
                     break;
                 }
             }

--- a/tests/src/test_node_flipbook.cpp
+++ b/tests/src/test_node_flipbook.cpp
@@ -568,7 +568,7 @@ TEST_CASE("LoopType::Reset rewinds to first step and stops playing", "[flipbook]
 // Tests — events
 // ---------------------------------------------------------------------------
 
-// Helper: attaches a Group as parent so SendEventUp has somewhere to go.
+// Helper: attaches a Group as parent so SendEvent has somewhere to go.
 static std::shared_ptr<Group> MakeGroupWithFlipbookChild(
     moth_ui::Context& ctx,
     std::shared_ptr<NodeFlipbook>& outFlipbook) {


### PR DESCRIPTION
## Summary

- `EventDirection::Down` was never used anywhere in the codebase
- All real callers used `EventDirection::Up`, which simply delegated to `SendEventUp()`
- Removes the dead enum, the direction-based dispatcher overload, and its internal `assert` branch
- Updates the three `SendEvent(..., EventDirection::Up)` call sites in `AnimationClipController` to call `SendEventUp()` directly

No behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Consolidated the event dispatch API into a single unified SendEvent interface, removing directional event routing options.
  * Events now propagate consistently through the parent-node chain, streamlining the scene-graph event system for all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->