### PR TITLE
fix: make Context non-copyable

### DIFF
--- a/include/moth_ui/context.h
+++ b/include/moth_ui/context.h
@@ -42,9 +42,9 @@ namespace moth_ui {
             return m_flipbookFactory;
         }
 
-        Context(Context const&) = default;
+        Context(Context const&) = delete;
+        Context& operator=(Context const&) = delete;
         Context(Context&&) = default;
-        Context& operator=(Context const&) = default;
         Context& operator=(Context&&) = default;
         ~Context() = default;
 


### PR DESCRIPTION
Closes #138.

`Context` held raw pointers to `IImageFactory`, `IFontFactory`, `IRenderer`, and `IFlipbookFactory`. With the default copy semantics, copying a `Context` would silently alias all four pointers. If the copy outlived the original (or the factories were destroyed first), all accesses via the copy would be undefined behaviour with no compile-time warning.

## Change

Delete the copy constructor and copy-assignment operator. Move constructor and move-assignment are kept — moving a `Context` transfers ownership cleanly.

```cpp
Context(Context const&) = delete;
Context& operator=(Context const&) = delete;
Context(Context&&) = default;
Context& operator=(Context&&) = default;
```

No call sites were copying `Context`; all existing code passes it by reference (`Context&`), so this is a zero-impact change in practice.