### PR TITLE
fix: return load result from NodeFactory::Create(path) instead of silent nullptr

### DIFF
--- a/include/moth_ui/layout/layout.h
+++ b/include/moth_ui/layout/layout.h
@@ -37,9 +37,10 @@ namespace moth_ui {
 
         /// @brief Result codes returned by Load().
         enum class LoadResult {
-            Success,         ///< Layout loaded successfully.
-            DoesNotExist,    ///< The specified file does not exist.
-            IncorrectFormat, ///< The file exists but could not be parsed.
+            Success,            ///< Layout loaded successfully.
+            DoesNotExist,       ///< The specified file does not exist.
+            IncorrectFormat,    ///< The file exists but could not be parsed.
+            InstantiationFailed, ///< The layout was parsed but could not be instantiated into a node.
         };
 
         /// @brief Options controlling how a layout is read from disk.

--- a/include/moth_ui/node_factory.h
+++ b/include/moth_ui/node_factory.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "moth_ui/context.h"
+#include "moth_ui/layout/layout.h"
 #include "moth_ui/moth_ui_fwd.h"
 
 #include <filesystem>
 #include <map>
 #include <memory>
 #include <shared_mutex>
+#include <utility>
 
 namespace moth_ui {
     /**
@@ -50,9 +52,10 @@ namespace moth_ui {
          * @param path    Path to the layout file.
          * @param width   Desired width in pixels.
          * @param height  Desired height in pixels.
-         * @return Root Group node, or @c nullptr on failure.
+         * @return Pair of the root Group (nullptr on failure) and the load result code.
+         *         The result code is @c Layout::LoadResult::Success on success.
          */
-        std::shared_ptr<Group> Create(Context& context, std::filesystem::path const& path, int width, int height);
+        std::pair<std::shared_ptr<Group>, Layout::LoadResult> Create(Context& context, std::filesystem::path const& path, int width, int height);
 
         /**
          * @brief Instantiates a Group node tree from a LayoutEntityGroup.

--- a/src/node_factory.cpp
+++ b/src/node_factory.cpp
@@ -21,6 +21,10 @@ namespace moth_ui {
         }
 
         auto resultNode = Create(context, std::static_pointer_cast<LayoutEntityGroup>(layout));
+        if (!resultNode) {
+            log::error("Failed to instantiate layout '{}'", path.string());
+            return { nullptr, Layout::LoadResult::InstantiationFailed };
+        }
 
         IntRect initialRect;
         initialRect.topLeft = { 0, 0 };

--- a/src/node_factory.cpp
+++ b/src/node_factory.cpp
@@ -13,12 +13,11 @@ namespace moth_ui {
         return className;
     }
 
-    std::shared_ptr<Group> NodeFactory::Create(Context& context, std::filesystem::path const& path, int width, int height) {
-        
+    std::pair<std::shared_ptr<Group>, Layout::LoadResult> NodeFactory::Create(Context& context, std::filesystem::path const& path, int width, int height) {
         auto [layout, loadResult] = Layout::Load(path);
         if (loadResult != Layout::LoadResult::Success) {
             log::error("Failed to load layout '{}': {}", path.string(), magic_enum::enum_name(loadResult));
-            return nullptr;
+            return { nullptr, loadResult };
         }
 
         auto resultNode = Create(context, std::static_pointer_cast<LayoutEntityGroup>(layout));
@@ -28,7 +27,7 @@ namespace moth_ui {
         initialRect.bottomRight = { width, height };
         resultNode->SetScreenRect(initialRect);
 
-        return resultNode;
+        return { resultNode, Layout::LoadResult::Success };
     }
 
     std::shared_ptr<Group> NodeFactory::Create(Context& context, std::shared_ptr<LayoutEntityGroup> group) {

--- a/tests/src/api_surface_factories.cpp
+++ b/tests/src/api_surface_factories.cpp
@@ -77,7 +77,7 @@ TEST_CASE("NodeFactory interface is stable", "[api][nodefactory]") {
     std::string (NodeFactory::*reg)(std::string const&, NodeFactory::CreationFunction const&)
         = &NodeFactory::RegisterWidget;
     // Create overloads
-    std::shared_ptr<Group> (NodeFactory::*createFromPath)(
+    std::pair<std::shared_ptr<Group>, Layout::LoadResult> (NodeFactory::*createFromPath)(
         Context&, std::filesystem::path const&, int, int) = &NodeFactory::Create;
     std::shared_ptr<Group> (NodeFactory::*createFromGroup)(
         Context&, std::shared_ptr<LayoutEntityGroup>)     = &NodeFactory::Create;


### PR DESCRIPTION
Closes #140.

`NodeFactory::Create(context, path, width, height)` returned `nullptr` on failure with no way to distinguish between a missing file and a malformed layout. The error was logged internally but callers had no structured way to react to it or surface a meaningful message.

## Change

The path-based overload now returns `std::pair<std::shared_ptr<Group>, Layout::LoadResult>`, matching the pattern already established by `Layout::Load`:

```cpp
// Before
std::shared_ptr<Group> Create(Context&, std::filesystem::path const&, int, int);

// After
std::pair<std::shared_ptr<Group>, Layout::LoadResult> Create(Context&, std::filesystem::path const&, int, int);
```

`Layout::LoadResult` is reused directly — the failure modes are identical (`DoesNotExist`, `IncorrectFormat`) and callers already know that enum. On success the node is non-null and the result is `LoadResult::Success`; on failure the node is `nullptr` and the result code identifies the cause.

The two entity-based overloads are unchanged — they always succeed given valid input and don't need a result code.

The API surface test is updated to pin the new signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated UI component creation to return both the component and a status indicator, enabling better error detection when loading layout files.

* **Tests**
  * Updated API surface tests to reflect the enhanced component creation interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->