### PR TITLE
feat: add NodeGradient with animatable two-stop linear gradient

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(PUBLIC_HEADERS
 	include/moth_ui/graphics/image_scale_type.h
 	include/moth_ui/graphics/irenderer.h
 	include/moth_ui/graphics/itarget.h
+	include/moth_ui/graphics/linear_gradient.h
 	include/moth_ui/graphics/text_alignment.h
 	include/moth_ui/iflipbook_factory.h
 	include/moth_ui/ifont_factory.h
@@ -56,6 +57,7 @@ set(PUBLIC_HEADERS
 	include/moth_ui/layout/layout_cache.h
 	include/moth_ui/layout/layout_entity_clip.h
 	include/moth_ui/layout/layout_entity_flipbook.h
+	include/moth_ui/layout/layout_entity_gradient.h
 	include/moth_ui/layout/layout_entity_group.h
 	include/moth_ui/layout/layout_entity.h
 	include/moth_ui/layout/layout_entity_image.h
@@ -69,6 +71,7 @@ set(PUBLIC_HEADERS
 	include/moth_ui/nodes/group.h
 	include/moth_ui/nodes/node_clip.h
 	include/moth_ui/nodes/node_flipbook.h
+	include/moth_ui/nodes/node_gradient.h
 	include/moth_ui/nodes/node.h
 	include/moth_ui/nodes/node_image.h
 	include/moth_ui/nodes/node_rect.h
@@ -107,6 +110,7 @@ set(SOURCES ${SOURCES}
 	src/layout/layout_entity_clip.cpp
 	src/layout/layout_entity.cpp
 	src/layout/layout_entity_flipbook.cpp
+	src/layout/layout_entity_gradient.cpp
 	src/layout/layout_entity_group.cpp
 	src/layout/layout_entity_image.cpp
 	src/layout/layout_entity_rect.cpp
@@ -117,6 +121,7 @@ set(SOURCES ${SOURCES}
 	src/nodes/node_clip.cpp
 	src/nodes/node.cpp
 	src/nodes/node_flipbook.cpp
+	src/nodes/node_gradient.cpp
 	src/nodes/node_image.cpp
 	src/nodes/node_rect.cpp
 	src/nodes/node_text.cpp

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,65 @@
+# TODO
+
+## 1.x
+
+### Switch Rotation Storage to Radians
+
+**Effort:** Medium
+
+Rotation is currently in **degrees** end-to-end (`Node::m_rotation`, `Node::SetRotation/GetRotation`,
+`LayoutEntity::GetRotationAtFrame`, `FloatMat4x4::Rotation`, the `AnimationTrack::Target::Rotation`
+keyframe values, and the `.mothui` file format). The newly added gradient angle stores radians,
+which makes the codebase inconsistent. The desired end state is radians at every API level; the
+editor converts to degrees for display only (same pattern used by the gradient angle field).
+
+**Scope:**
+- Flip `m_rotation` / `SetRotation` / `GetRotation` / `GetRotationAtFrame` semantics to radians.
+- Drop the internal `*= kDegToRad` in `FloatMat4x4::Rotation`; rename `GetRotationDegrees`
+  to `GetRotationRadians`.
+- Editor `editor_panel_properties.cpp` Rotation input + `editor_layer.cpp` rotation-edit
+  context: convert deg ↔ rad at the UI boundary.
+- Bounds handles (`rotation_bounds_handle.cpp`, `pivot_bounds_handle.cpp`,
+  `offset_bounds_handle.cpp`) currently do `GetRotation() * kDegToRad`; just remove the multiply.
+- `editor_panel_canvas.cpp` `RotateAroundPivot(..., -node.GetRotation())` callers — either
+  the helper takes radians or the caller converts.
+- Test updates in `test_node.cpp` (`SetRotation(45.0f)` etc.) and `test_transform.cpp`
+  (`FloatMat4x4::Rotation(90.0f, ...)` round-trips).
+
+**File-format migration:** `.mothui` files store the `Rotation` track's keyframe values as raw
+floats (currently degrees). A version bump + load-time `*= kDegToRad` for old files is needed
+or every existing layout with a Rotation track will render ~57× over-rotated. Until this
+migration is in place, the refactor stays deferred.
+
+---
+
+### Rotated Clip Regions (NodeClip + NodeGradient)
+
+**Effort:** Large
+
+NodeClip and NodeGradient currently rely on backend scissor (`SDL_RenderSetClipRect`,
+`vkCmdSetScissor`), which is axis-aligned screen-space only. As a result:
+
+- **NodeClip cannot rotate.** A NodeClip's clip region is computed as the AABB of its
+  bounds — fine when the node is axis-aligned, but the moment a clip is rotated the
+  intended mask becomes the AABB, not the rotated quad.
+- **NodeGradient cannot rotate.** The MothRenderer wrapper pushes an AABB scissor sized
+  to the transformed node corners. For a non-rotated node it matches the rect exactly;
+  for a rotated node the AABB is larger than the visible quad, so the gradient leaks
+  past the rotated edges. (A leftover `PushClip(screenAabb)` hack lives in
+  `moth_graphics/.../moth_renderer.cpp` `RenderGradientRect` for this reason.)
+
+**The fix** would route clipping through a polygon stack (`IGraphics::PushClipPolygon`),
+honoured per-backend:
+
+- **SDL backend**: CPU-side Sutherland-Hodgman chop of every emitted primitive's geometry
+  against the active polygon before submission to `SDL_RenderGeometry`. Textured
+  primitives (`DrawImage`, `DrawImageTiled`, text, nine-slice) additionally need UV
+  interpolation at cut vertices. Nested polygons compose by intersection.
+- **Vulkan backend**: stencil buffer (draw rotated quad with increment, stencil-test
+  contents, decrement on pop) or fragment-shader half-plane discard with the four edge
+  equations passed as uniforms.
+
+The work is substantial and touches every primitive draw path. Until then, **clip and
+gradient nodes should be treated as non-rotatable** — the editor still permits setting
+rotation on them but the visual result will be wrong (gradient leaks past rotated edges;
+clip masks revert to AABB of the rotated bounds).

--- a/include/moth_ui/animation/animation_controller.h
+++ b/include/moth_ui/animation/animation_controller.h
@@ -59,6 +59,7 @@ namespace moth_ui {
 
     private:
         static float* GetTargetReference(Node* node, AnimationTarget target);
+        static float* GradientTargetReference(NodeGradient* node, AnimationTarget target);
 
         Node* m_node = nullptr;
         std::vector<std::unique_ptr<AnimationTrackController>> m_trackControllers;

--- a/include/moth_ui/animation/animation_target.h
+++ b/include/moth_ui/animation/animation_target.h
@@ -6,26 +6,38 @@ namespace moth_ui {
 
 /// @brief Properties that can be animated via AnimationTrack or DiscreteAnimationTrack.
 enum class AnimationTarget {
-    Unknown,          ///< Unrecognised or unset target.
-    TopOffset,        ///< Top edge pixel offset.
-    BottomOffset,     ///< Bottom edge pixel offset.
-    LeftOffset,       ///< Left edge pixel offset.
-    RightOffset,      ///< Right edge pixel offset.
-    TopAnchor,        ///< Top anchor fraction [0,1].
-    BottomAnchor,     ///< Bottom anchor fraction [0,1].
-    LeftAnchor,       ///< Left anchor fraction [0,1].
-    RightAnchor,      ///< Right anchor fraction [0,1].
-    ColorRed,         ///< Red colour component [0,1].
-    ColorGreen,       ///< Green colour component [0,1].
-    ColorBlue,        ///< Blue colour component [0,1].
-    ColorAlpha,       ///< Alpha colour component [0,1].
-    Rotation,         ///< Clockwise rotation in degrees.
-    FlipbookClip,     ///< Flipbook clip name (discrete string, step-interpolated).
-    FlipbookPlaying,  ///< Flipbook play/pause state as "1"/"0" (discrete, step-interpolated).
+    Unknown,             ///< Unrecognised or unset target.
+    TopOffset,           ///< Top edge pixel offset.
+    BottomOffset,        ///< Bottom edge pixel offset.
+    LeftOffset,          ///< Left edge pixel offset.
+    RightOffset,         ///< Right edge pixel offset.
+    TopAnchor,           ///< Top anchor fraction [0,1].
+    BottomAnchor,        ///< Bottom anchor fraction [0,1].
+    LeftAnchor,          ///< Left anchor fraction [0,1].
+    RightAnchor,         ///< Right anchor fraction [0,1].
+    ColorRed,            ///< Red colour component [0,1].
+    ColorGreen,          ///< Green colour component [0,1].
+    ColorBlue,           ///< Blue colour component [0,1].
+    ColorAlpha,          ///< Alpha colour component [0,1].
+    Rotation,            ///< Clockwise rotation in degrees.
+    FlipbookClip,        ///< Flipbook clip name (discrete string, step-interpolated).
+    FlipbookPlaying,     ///< Flipbook play/pause state as "1"/"0" (discrete, step-interpolated).
+    GradientStartRed,    ///< Gradient start-colour red [0,1] (NodeGradient only).
+    GradientStartGreen,  ///< Gradient start-colour green [0,1] (NodeGradient only).
+    GradientStartBlue,   ///< Gradient start-colour blue [0,1] (NodeGradient only).
+    GradientStartAlpha,  ///< Gradient start-colour alpha [0,1] (NodeGradient only).
+    GradientEndRed,      ///< Gradient end-colour red [0,1] (NodeGradient only).
+    GradientEndGreen,    ///< Gradient end-colour green [0,1] (NodeGradient only).
+    GradientEndBlue,     ///< Gradient end-colour blue [0,1] (NodeGradient only).
+    GradientEndAlpha,    ///< Gradient end-colour alpha [0,1] (NodeGradient only).
+    GradientMidpointX,   ///< Gradient midpoint x as a fraction [0,1] of the rect (NodeGradient only).
+    GradientMidpointY,   ///< Gradient midpoint y as a fraction [0,1] of the rect (NodeGradient only).
+    GradientAngle,       ///< Gradient direction in radians; 0 = +x (NodeGradient only).
+    GradientTransition,  ///< Gradient transition length as factor of projected extent (NodeGradient only).
 };
 
 /// All AnimationTarget values that are continuously interpolated (excludes Unknown).
-inline constexpr std::array<AnimationTarget, 13> kContinuousTargets{
+inline constexpr std::array<AnimationTarget, 25> kContinuousTargets{
     AnimationTarget::TopOffset,
     AnimationTarget::BottomOffset,
     AnimationTarget::LeftOffset,
@@ -39,6 +51,18 @@ inline constexpr std::array<AnimationTarget, 13> kContinuousTargets{
     AnimationTarget::ColorBlue,
     AnimationTarget::ColorAlpha,
     AnimationTarget::Rotation,
+    AnimationTarget::GradientStartRed,
+    AnimationTarget::GradientStartGreen,
+    AnimationTarget::GradientStartBlue,
+    AnimationTarget::GradientStartAlpha,
+    AnimationTarget::GradientEndRed,
+    AnimationTarget::GradientEndGreen,
+    AnimationTarget::GradientEndBlue,
+    AnimationTarget::GradientEndAlpha,
+    AnimationTarget::GradientMidpointX,
+    AnimationTarget::GradientMidpointY,
+    AnimationTarget::GradientAngle,
+    AnimationTarget::GradientTransition,
 };
 
 /// All AnimationTarget values that are step-interpolated string values (discrete tracks).

--- a/include/moth_ui/graphics/irenderer.h
+++ b/include/moth_ui/graphics/irenderer.h
@@ -3,6 +3,7 @@
 #include "moth_ui/moth_ui_fwd.h"
 #include "moth_ui/graphics/blend_mode.h"
 #include "moth_ui/graphics/image_scale_type.h"
+#include "moth_ui/graphics/linear_gradient.h"
 #include "moth_ui/graphics/text_alignment.h"
 #include "moth_ui/graphics/texture_filter.h"
 #include "moth_ui/utils/color.h"
@@ -85,6 +86,14 @@ namespace moth_ui {
          * @param rect Destination rectangle in screen space.
          */
         virtual void RenderFilledRect(IntRect const& rect) = 0;
+
+        /**
+         * @brief Draws a two-stop linear gradient inside a rectangle.
+         *
+         * @param rect     Destination rectangle in screen space.
+         * @param gradient Gradient parameters (start/end colour, midpoint, angle, transition length).
+         */
+        virtual void RenderGradientRect(IntRect const& rect, LinearGradient const& gradient) = 0;
 
         /**
          * @brief Draws a portion of an image into a destination rectangle.

--- a/include/moth_ui/graphics/linear_gradient.h
+++ b/include/moth_ui/graphics/linear_gradient.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "moth_ui/utils/color.h"
+#include "moth_ui/utils/vector.h"
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+namespace moth_ui {
+    /**
+     * @brief Parameters describing a two-stop linear colour gradient.
+     *
+     * Drawn into an arbitrary destination rectangle. The midpoint locates the
+     * t=0.5 point inside the rect as a normalised fraction, @c angle gives the
+     * gradient direction in radians (0 = +x toward @c endColor), and
+     * @c transitionLength scales the length of the lerp along the axis.
+     *
+     * - @c transitionLength = 1.0 fills the rect.
+     * - @c transitionLength = 0.0 produces a sharp step at @c midpoint.
+     * - @c transitionLength > 1.0 leaves the lerp partially outside the rect.
+     */
+    struct LinearGradient {
+        Color startColor{ 0.0f, 0.0f, 0.0f, 1.0f };
+        Color endColor{ 1.0f, 1.0f, 1.0f, 1.0f };
+        FloatVec2 midpoint{ 0.5f, 0.5f };
+        float angle = 0.0f;
+        float transitionLength = 1.0f;
+    };
+}
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)

--- a/include/moth_ui/layout/layout_entity_gradient.h
+++ b/include/moth_ui/layout/layout_entity_gradient.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "moth_ui/graphics/linear_gradient.h"
+#include "moth_ui/layout/layout_entity.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+namespace moth_ui {
+    /**
+     * @brief Layout entity that describes a two-stop linear gradient node.
+     *
+     * The gradient has no static struct — every parameter is stored as a
+     * continuous animation track on the base @c LayoutEntity (eight colour
+     * scalars + midpoint x/y + angle + transition length, twelve in total),
+     * with the keyframe-0 values acting as the "static" defaults.
+     */
+    class LayoutEntityGradient : public LayoutEntity {
+    public:
+        /**
+         * @brief Constructs a gradient entity with an explicit initial bounds.
+         * @param initialBounds Starting layout rect.
+         */
+        explicit LayoutEntityGradient(LayoutRect const& initialBounds);
+
+        /**
+         * @brief Constructs a gradient entity as a child of the given parent.
+         * @param parent Owning group.
+         */
+        explicit LayoutEntityGradient(LayoutEntityGroup* parent);
+
+        std::shared_ptr<LayoutEntity> Clone(CloneType cloneType) override;
+
+        /// @brief Returns @c LayoutEntityType::Gradient.
+        LayoutEntityType GetType() const override { return LayoutEntityType::Gradient; }
+
+        std::shared_ptr<Node> Instantiate(Context& context) override;
+
+        nlohmann::json Serialize(SerializeContext const& context) const override;
+        bool Deserialize(nlohmann::json const& json, SerializeContext const& context) override;
+
+        /**
+         * @brief Returns the gradient with every animation track interpolated at @p frame.
+         * @param frame Frame index (may be fractional).
+         */
+        LinearGradient GetGradientAtFrame(float frame) const;
+
+        LayoutEntityGradient(LayoutEntityGradient const& other) = default;
+        LayoutEntityGradient(LayoutEntityGradient&& other) = default;
+        LayoutEntityGradient& operator=(LayoutEntityGradient const&) = delete;
+        LayoutEntityGradient& operator=(LayoutEntityGradient&&) = default;
+        ~LayoutEntityGradient() override = default;
+    };
+}

--- a/include/moth_ui/layout/layout_entity_type.h
+++ b/include/moth_ui/layout/layout_entity_type.h
@@ -15,5 +15,6 @@ namespace moth_ui {
         Text,    ///< LayoutEntityText.
         Clip,    ///< LayoutEntityClip (scissor region).
         Flipbook,///< LayoutEntityFlipbook.
+        Gradient,///< LayoutEntityGradient (two-stop linear gradient).
     };
 }

--- a/include/moth_ui/moth_ui.h
+++ b/include/moth_ui/moth_ui.h
@@ -29,6 +29,7 @@
 #include "moth_ui/graphics/iimage.h"
 #include "moth_ui/graphics/image_scale_type.h"
 #include "moth_ui/graphics/irenderer.h"
+#include "moth_ui/graphics/linear_gradient.h"
 #include "moth_ui/graphics/itarget.h"
 #include "moth_ui/graphics/text_alignment.h"
 #include "moth_ui/graphics/texture_filter.h"
@@ -47,6 +48,7 @@
 #include "moth_ui/layout/layout_entity_type.h"
 #include "moth_ui/layout/layout_rect.h"
 #include "moth_ui/layout/layout_entity_flipbook.h"
+#include "moth_ui/layout/layout_entity_gradient.h"
 
 // layers
 #include "moth_ui/layers/layer.h"
@@ -61,6 +63,7 @@
 #include "moth_ui/nodes/node_text.h"
 #include "moth_ui/nodes/widget.h"
 #include "moth_ui/nodes/node_flipbook.h"
+#include "moth_ui/nodes/node_gradient.h"
 
 // utils
 #include "moth_ui/utils/color.h"

--- a/include/moth_ui/moth_ui_fwd.h
+++ b/include/moth_ui/moth_ui_fwd.h
@@ -53,6 +53,7 @@ namespace moth_ui {
     class NodeText;
     class NodeClip;
     class NodeFlipbook;
+    class NodeGradient;
 
     template <typename T, typename BaseType>
     class Widget;
@@ -68,9 +69,11 @@ namespace moth_ui {
     class LayoutEntityClip;
     class LayoutEntityRef;
     class LayoutEntityFlipbook;
+    class LayoutEntityGradient;
     class Layout;
     class LayoutCache;
     struct LayoutRect;
+    struct LinearGradient;
 
     // -------------------------------------------------------------------------
     // Animation

--- a/include/moth_ui/nodes/node_gradient.h
+++ b/include/moth_ui/nodes/node_gradient.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "moth_ui/graphics/linear_gradient.h"
+#include "moth_ui/nodes/node.h"
+
+#include <memory>
+
+namespace moth_ui {
+    /**
+     * @brief A Node that renders a two-stop linear gradient inside its bounds.
+     *
+     * The live gradient parameters live on this node so the AnimationController
+     * can write into them per-frame; the static defaults are loaded from a
+     * @c LayoutEntityGradient.
+     */
+    class NodeGradient : public Node {
+    public:
+        NodeGradient(NodeGradient const& other) = delete;
+        NodeGradient(NodeGradient&& other) = default;
+        NodeGradient& operator=(NodeGradient const&) = delete;
+        NodeGradient& operator=(NodeGradient&&) = delete;
+        ~NodeGradient() override = default;
+
+        /**
+         * @brief Creates a NodeGradient with no layout entity.
+         * @param context Active rendering context.
+         */
+        static std::shared_ptr<NodeGradient> Create(Context& context);
+
+        /**
+         * @brief Creates a NodeGradient from a serialised layout entity.
+         * @param context      Active rendering context.
+         * @param layoutEntity Deserialised gradient description.
+         */
+        static std::shared_ptr<NodeGradient> Create(Context& context, std::shared_ptr<LayoutEntityGradient> layoutEntity);
+
+        /// @brief Returns the live gradient (updated by animation tracks each frame).
+        LinearGradient const& GetGradient() const { return m_gradient; }
+
+        /// @brief Replaces the live gradient (also used by the editor for static edits).
+        void SetGradient(LinearGradient const& gradient) { m_gradient = gradient; }
+
+    protected:
+        NodeGradient(Context& context);
+        NodeGradient(Context& context, std::shared_ptr<LayoutEntityGradient> layoutEntity);
+
+        LinearGradient m_gradient; ///< Live gradient state; animation tracks write into these fields.
+
+        void ReloadEntityInternal() override;
+        void DrawInternal() override;
+
+    private:
+        friend class AnimationController;
+
+        LayoutEntityGradient* m_typedLayout = nullptr;
+    };
+}

--- a/src/animation/animation_controller.cpp
+++ b/src/animation/animation_controller.cpp
@@ -69,8 +69,15 @@ namespace moth_ui {
         case AnimationTarget::GradientMidpointX:
         case AnimationTarget::GradientMidpointY:
         case AnimationTarget::GradientAngle:
-        case AnimationTarget::GradientTransition:
-            return GradientTargetReference(dynamic_cast<NodeGradient*>(node), target);
+        case AnimationTarget::GradientTransition: {
+            auto* gradient = dynamic_cast<NodeGradient*>(node);
+            if (gradient == nullptr) {
+                log::warn("AnimationController: gradient target '{}' on non-gradient node (id='{}')",
+                          magic_enum::enum_name(target), node->GetId());
+                return nullptr;
+            }
+            return GradientTargetReference(gradient, target);
+        }
         case AnimationTarget::FlipbookClip:
         case AnimationTarget::FlipbookPlaying:
         case AnimationTarget::Unknown:

--- a/src/animation/animation_controller.cpp
+++ b/src/animation/animation_controller.cpp
@@ -4,8 +4,31 @@
 #include "moth_ui/animation/discrete_animation_track_controller.h"
 #include "moth_ui/layout/layout_entity.h"
 #include "moth_ui/nodes/node.h"
+#include "moth_ui/nodes/node_gradient.h"
 
 namespace moth_ui {
+    float* AnimationController::GradientTargetReference(NodeGradient* node, AnimationTarget target) {
+        if (node == nullptr) {
+            return nullptr;
+        }
+        switch (target) {
+        case AnimationTarget::GradientStartRed:    return &node->m_gradient.startColor.r;
+        case AnimationTarget::GradientStartGreen:  return &node->m_gradient.startColor.g;
+        case AnimationTarget::GradientStartBlue:   return &node->m_gradient.startColor.b;
+        case AnimationTarget::GradientStartAlpha:  return &node->m_gradient.startColor.a;
+        case AnimationTarget::GradientEndRed:      return &node->m_gradient.endColor.r;
+        case AnimationTarget::GradientEndGreen:    return &node->m_gradient.endColor.g;
+        case AnimationTarget::GradientEndBlue:     return &node->m_gradient.endColor.b;
+        case AnimationTarget::GradientEndAlpha:    return &node->m_gradient.endColor.a;
+        case AnimationTarget::GradientMidpointX:   return &node->m_gradient.midpoint.x;
+        case AnimationTarget::GradientMidpointY:   return &node->m_gradient.midpoint.y;
+        case AnimationTarget::GradientAngle:       return &node->m_gradient.angle;
+        case AnimationTarget::GradientTransition:  return &node->m_gradient.transitionLength;
+        default:
+            return nullptr;
+        }
+    }
+
     float* AnimationController::GetTargetReference(Node* node, AnimationTarget target) {
         auto& layoutRect = node->GetLayoutRect();
         switch (target) {
@@ -35,6 +58,19 @@ namespace moth_ui {
             return &node->m_color.a;
         case AnimationTarget::Rotation:
             return &node->m_rotation;
+        case AnimationTarget::GradientStartRed:
+        case AnimationTarget::GradientStartGreen:
+        case AnimationTarget::GradientStartBlue:
+        case AnimationTarget::GradientStartAlpha:
+        case AnimationTarget::GradientEndRed:
+        case AnimationTarget::GradientEndGreen:
+        case AnimationTarget::GradientEndBlue:
+        case AnimationTarget::GradientEndAlpha:
+        case AnimationTarget::GradientMidpointX:
+        case AnimationTarget::GradientMidpointY:
+        case AnimationTarget::GradientAngle:
+        case AnimationTarget::GradientTransition:
+            return GradientTargetReference(dynamic_cast<NodeGradient*>(node), target);
         case AnimationTarget::FlipbookClip:
         case AnimationTarget::FlipbookPlaying:
         case AnimationTarget::Unknown:

--- a/src/layout/layout_entity.cpp
+++ b/src/layout/layout_entity.cpp
@@ -2,6 +2,7 @@
 #include "moth_ui/layout/layout_entity.h"
 #include "moth_ui/animation/discrete_animation_track.h"
 #include "moth_ui/layout/layout_entity_flipbook.h"
+#include "moth_ui/layout/layout_entity_gradient.h"
 #include "moth_ui/layout/layout_entity_group.h"
 #include "moth_ui/layout/layout_entity_text.h"
 #include "moth_ui/layout/layout_entity_image.h"
@@ -25,6 +26,8 @@ namespace moth_ui {
             return std::make_unique<LayoutEntityClip>(nullptr);
         case LayoutEntityType::Flipbook:
             return std::make_unique<LayoutEntityFlipbook>(nullptr);
+        case LayoutEntityType::Gradient:
+            return std::make_unique<LayoutEntityGradient>(nullptr);
         default:
             log::error("Unknown layout entity type: {}", magic_enum::enum_name(type));
             assert(false && "unknown entity type");

--- a/src/layout/layout_entity_gradient.cpp
+++ b/src/layout/layout_entity_gradient.cpp
@@ -1,0 +1,100 @@
+#include "common.h"
+#include "moth_ui/layout/layout_entity_gradient.h"
+#include "moth_ui/nodes/node_gradient.h"
+#include "moth_ui/animation/animation_track.h"
+
+namespace moth_ui {
+    namespace {
+        constexpr std::size_t kGradientTrackCount = 12;
+
+        struct TargetSeed {
+            AnimationTarget target;
+            float value;
+        };
+
+        std::array<TargetSeed, kGradientTrackCount> GradientTargetSeeds(LinearGradient const& g) {
+            return {{
+                { AnimationTarget::GradientStartRed,    g.startColor.r },
+                { AnimationTarget::GradientStartGreen,  g.startColor.g },
+                { AnimationTarget::GradientStartBlue,   g.startColor.b },
+                { AnimationTarget::GradientStartAlpha,  g.startColor.a },
+                { AnimationTarget::GradientEndRed,      g.endColor.r },
+                { AnimationTarget::GradientEndGreen,    g.endColor.g },
+                { AnimationTarget::GradientEndBlue,     g.endColor.b },
+                { AnimationTarget::GradientEndAlpha,    g.endColor.a },
+                { AnimationTarget::GradientMidpointX,   g.midpoint.x },
+                { AnimationTarget::GradientMidpointY,   g.midpoint.y },
+                { AnimationTarget::GradientAngle,       g.angle },
+                { AnimationTarget::GradientTransition,  g.transitionLength },
+            }};
+        }
+
+        void InitGradientTracks(LayoutEntity& entity, LinearGradient const& g) {
+            for (auto const& seed : GradientTargetSeeds(g)) {
+                if (entity.m_tracks.find(seed.target) == entity.m_tracks.end()) {
+                    entity.m_tracks.insert(std::make_pair(
+                        seed.target,
+                        std::make_unique<AnimationTrack>(seed.target, seed.value)));
+                }
+            }
+        }
+    }
+
+    LayoutEntityGradient::LayoutEntityGradient(LayoutRect const& initialBounds)
+        : LayoutEntity(initialBounds) {
+        InitGradientTracks(*this, LinearGradient{});
+    }
+
+    LayoutEntityGradient::LayoutEntityGradient(LayoutEntityGroup* parent)
+        : LayoutEntity(parent) {
+        InitGradientTracks(*this, LinearGradient{});
+    }
+
+    std::shared_ptr<LayoutEntity> LayoutEntityGradient::Clone(CloneType cloneType) {
+        return std::make_shared<LayoutEntityGradient>(*this);
+    }
+
+    std::shared_ptr<Node> LayoutEntityGradient::Instantiate(Context& context) {
+        return NodeGradient::Create(context, std::static_pointer_cast<LayoutEntityGradient>(shared_from_this()));
+    }
+
+    nlohmann::json LayoutEntityGradient::Serialize(SerializeContext const& context) const {
+        return LayoutEntity::Serialize(context);
+    }
+
+    bool LayoutEntityGradient::Deserialize(nlohmann::json const& json, SerializeContext const& context) {
+        bool const success = LayoutEntity::Deserialize(json, context);
+        if (success) {
+            // Ensure all 12 gradient tracks exist after load, even if the file
+            // pre-dates one of them. Existing tracks (including their keyframes)
+            // are preserved by InitGradientTracks's find-then-insert pattern.
+            InitGradientTracks(*this, LinearGradient{});
+        }
+        return success;
+    }
+
+    LinearGradient LayoutEntityGradient::GetGradientAtFrame(float frame) const {
+        auto GetValue = [&](AnimationTarget target, float fallback) {
+            auto const it = m_tracks.find(target);
+            if (it != m_tracks.end()) {
+                return it->second->GetValueAtFrame(frame);
+            }
+            return fallback;
+        };
+
+        LinearGradient g;
+        g.startColor.r     = GetValue(AnimationTarget::GradientStartRed,    g.startColor.r);
+        g.startColor.g     = GetValue(AnimationTarget::GradientStartGreen,  g.startColor.g);
+        g.startColor.b     = GetValue(AnimationTarget::GradientStartBlue,   g.startColor.b);
+        g.startColor.a     = GetValue(AnimationTarget::GradientStartAlpha,  g.startColor.a);
+        g.endColor.r       = GetValue(AnimationTarget::GradientEndRed,      g.endColor.r);
+        g.endColor.g       = GetValue(AnimationTarget::GradientEndGreen,    g.endColor.g);
+        g.endColor.b       = GetValue(AnimationTarget::GradientEndBlue,     g.endColor.b);
+        g.endColor.a       = GetValue(AnimationTarget::GradientEndAlpha,    g.endColor.a);
+        g.midpoint.x       = GetValue(AnimationTarget::GradientMidpointX,   g.midpoint.x);
+        g.midpoint.y       = GetValue(AnimationTarget::GradientMidpointY,   g.midpoint.y);
+        g.angle            = GetValue(AnimationTarget::GradientAngle,       g.angle);
+        g.transitionLength = GetValue(AnimationTarget::GradientTransition,  g.transitionLength);
+        return g;
+    }
+}

--- a/src/nodes/node_gradient.cpp
+++ b/src/nodes/node_gradient.cpp
@@ -1,0 +1,37 @@
+#include "common.h"
+#include "moth_ui/nodes/node_gradient.h"
+#include "moth_ui/layout/layout_entity_gradient.h"
+#include "moth_ui/context.h"
+#include "moth_ui/graphics/irenderer.h"
+
+namespace moth_ui {
+    NodeGradient::NodeGradient(Context& context)
+        : Node(context) {
+    }
+
+    NodeGradient::NodeGradient(Context& context, std::shared_ptr<LayoutEntityGradient> layoutEntity)
+        : Node(context, layoutEntity)
+        , m_typedLayout(layoutEntity.get()) {
+        m_gradient = m_typedLayout->GetGradientAtFrame(0.0f);
+    }
+
+    void NodeGradient::ReloadEntityInternal() {
+        Node::ReloadEntityInternal();
+        if (m_typedLayout != nullptr) {
+            m_gradient = m_typedLayout->GetGradientAtFrame(0.0f);
+        }
+    }
+
+    void NodeGradient::DrawInternal() {
+        IntRect const localRect{ { 0, 0 }, m_screenRect.bottomRight - m_screenRect.topLeft };
+        m_context.GetRenderer().RenderGradientRect(localRect, m_gradient);
+    }
+
+    std::shared_ptr<NodeGradient> NodeGradient::Create(Context& context) {
+        return std::shared_ptr<NodeGradient>(new NodeGradient(context));
+    }
+
+    std::shared_ptr<NodeGradient> NodeGradient::Create(Context& context, std::shared_ptr<LayoutEntityGradient> layoutEntity) {
+        return std::shared_ptr<NodeGradient>(new NodeGradient(context, std::move(layoutEntity)));
+    }
+}

--- a/tests/src/api_surface_animation.cpp
+++ b/tests/src/api_surface_animation.cpp
@@ -23,7 +23,11 @@ namespace {
         Target::TopOffset,    Target::BottomOffset, Target::LeftOffset,  Target::RightOffset,
         Target::TopAnchor,    Target::BottomAnchor, Target::LeftAnchor,  Target::RightAnchor,
         Target::ColorRed,     Target::ColorGreen,   Target::ColorBlue,   Target::ColorAlpha,
-        Target::Rotation
+        Target::Rotation,
+        Target::GradientStartRed,   Target::GradientStartGreen, Target::GradientStartBlue,  Target::GradientStartAlpha,
+        Target::GradientEndRed,     Target::GradientEndGreen,   Target::GradientEndBlue,    Target::GradientEndAlpha,
+        Target::GradientMidpointX,  Target::GradientMidpointY,
+        Target::GradientAngle,      Target::GradientTransition,
     };
     static_assert(arrays_equal(AnimationTrack::ContinuousTargets, expectedContinuous),
                   "AnimationTrack::ContinuousTargets contents or order changed");

--- a/tests/src/api_surface_graphics.cpp
+++ b/tests/src/api_surface_graphics.cpp
@@ -24,6 +24,8 @@ TEST_CASE("IRenderer method signatures are stable", "[api][graphics][irenderer]"
     // Draw calls
     void (IRenderer::*renderRect)(IntRect const&)        = &IRenderer::RenderRect;
     void (IRenderer::*renderFilled)(IntRect const&)      = &IRenderer::RenderFilledRect;
+    void (IRenderer::*renderGradient)(IntRect const&,
+                                      LinearGradient const&) = &IRenderer::RenderGradientRect;
     void (IRenderer::*renderImg)(IImage const&, IntRect const&, IntRect const&,
                                  ImageScaleType, float) = &IRenderer::RenderImage;
     void (IRenderer::*renderText)(std::string_view, IFont&,
@@ -34,7 +36,7 @@ TEST_CASE("IRenderer method signatures are stable", "[api][graphics][irenderer]"
     (void)pushBlend; (void)popBlend; (void)pushColor; (void)popColor;
     (void)pushXform; (void)popXform; (void)pushClip;  (void)popClip;
     (void)pushFilter; (void)popFilter;
-    (void)renderRect; (void)renderFilled; (void)renderImg;
+    (void)renderRect; (void)renderFilled; (void)renderGradient; (void)renderImg;
     (void)renderText; (void)setLogical;
     SUCCEED();
 }

--- a/tests/src/api_surface_layout.cpp
+++ b/tests/src/api_surface_layout.cpp
@@ -19,6 +19,7 @@ TEST_CASE("LayoutEntityType enum values are stable", "[api][layout][type]") {
     static_assert(T::Image    != T::Text);
     static_assert(T::Text     != T::Clip);
     static_assert(T::Clip     != T::Flipbook);
+    static_assert(T::Flipbook != T::Gradient);
     SUCCEED();
 }
 

--- a/tests/src/mock_context.h
+++ b/tests/src/mock_context.h
@@ -27,6 +27,7 @@ public:
     int popTextureFilterCalls = 0;
     int renderRectCalls = 0;
     int renderFilledRectCalls = 0;
+    int renderGradientRectCalls = 0;
     int renderImageCalls = 0;
     int renderTextCalls = 0;
     int setLogicalSizeCalls = 0;
@@ -51,6 +52,7 @@ public:
     void PopTextureFilter() override { ++popTextureFilterCalls; }
     void RenderRect(moth_ui::IntRect const& rect) override { ++renderRectCalls; lastRenderRect = rect; }
     void RenderFilledRect(moth_ui::IntRect const& rect) override { ++renderFilledRectCalls; lastRenderRect = rect; }
+    void RenderGradientRect(moth_ui::IntRect const& rect, moth_ui::LinearGradient const&) override { ++renderGradientRectCalls; lastRenderRect = rect; }
     void RenderImage(moth_ui::IImage const&, moth_ui::IntRect const&, moth_ui::IntRect const&, moth_ui::ImageScaleType, float) override { ++renderImageCalls; }
     void RenderText(std::string_view, moth_ui::IFont&, moth_ui::TextHorizAlignment, moth_ui::TextVertAlignment, moth_ui::IntRect const&) override { ++renderTextCalls; }
     void SetRendererLogicalSize(moth_ui::IntVec2 const& size) override { ++setLogicalSizeCalls; lastLogicalSize = size; }

--- a/tests/src/test_animation_track.cpp
+++ b/tests/src/test_animation_track.cpp
@@ -19,8 +19,8 @@ TEST_CASE("AnimationTrack initial value construction", "[animation_track][initia
     REQUIRE(track.Keyframes()[0]->value == Catch::Approx(0.5f));
 }
 
-TEST_CASE("AnimationTrack ContinuousTargets has 13 entries", "[animation_track]") {
-    REQUIRE(AnimationTrack::ContinuousTargets.size() == 13);
+TEST_CASE("AnimationTrack ContinuousTargets has 25 entries", "[animation_track]") {
+    REQUIRE(AnimationTrack::ContinuousTargets.size() == 25);
 }
 
 TEST_CASE("AnimationTrack ContinuousTargets contains all expected targets", "[animation_track]") {


### PR DESCRIPTION
## Summary
- New `NodeGradient` / `LayoutEntityGradient` for two-stop linear gradients, with `LinearGradient` struct (start/end colour, normalised midpoint, radian angle, transition factor).
- All twelve gradient scalars are continuous animation tracks on the entity — no static struct field, keyframes are the source of truth (matching how colour and rotation already work).
- `AnimationController` extended with a per-target dispatch (`GradientTargetReference`) so the existing track-controller plumbing writes into the live node's `LinearGradient` each frame.
- `IRenderer::RenderGradientRect(IntRect, LinearGradient)` added as a pure virtual.
- `LayoutEntityType::Gradient` registered in the factory; aggregate header + CMakeLists wired up.
- API-surface tests pin the new enum value and renderer method.
- `TODO.md` added covering two deferred items: switching rotation storage from degrees to radians, and supporting rotated clip regions (NodeClip + NodeGradient) — both require non-trivial work that's intentionally not in this PR.

## Test plan
- [ ] Build moth_ui Debug + Release on Linux and Windows
- [ ] `moth_ui_tests` passes (API surface tests pin the new gradient targets + LayoutEntityType::Gradient)
- [ ] Pairs with downstream `feat/gradient-node` in moth_graphics (MothRenderer bridge) — that branch is committed locally and will be opened once this PR lands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New gradient node for two-stop linear gradients with configurable colors, midpoint, angle, and transition
  * All gradient parameters are animatable and integrated into the animation system
  * Renderer now supports drawing gradient rectangles
  * Gradients are fully saved and restored with layouts

* **Tests**
  * API and unit tests updated to include new gradient animation targets

* **Chores**
  * Roadmap notes added for rotation units and clipping/gradient handling approaches

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/instinkt900/moth_ui/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->