### PR TITLE
feat: add opt-in flow navigation utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set(PUBLIC_HEADERS
 	include/moth_ui/utils/vector_utils.h
 	include/moth_ui/version.h
 	include/moth_ui/widgets/ui_button.h
+	include/moth_ui/widgets/ui_scroll_view.h
 	include/moth_ui/widgets/widget.h
 )
 set(SOURCES ${SOURCES}
@@ -136,6 +137,7 @@ set(SOURCES ${SOURCES}
 	src/nodes/node_rect.cpp
 	src/nodes/node_text.cpp
 	src/widgets/ui_button.cpp
+	src/widgets/ui_scroll_view.cpp
 	src/widgets/widget.cpp
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,12 @@ set(PUBLIC_HEADERS
 	include/moth_ui/events/event_key.h
 	include/moth_ui/events/event_listener.h
 	include/moth_ui/events/event_mouse.h
+	include/moth_ui/flow/code_driven_layer.h
+	include/moth_ui/flow/flow.h
+	include/moth_ui/flow/flow_graph.h
+	include/moth_ui/flow/iclickable.h
+	include/moth_ui/flow/transition_participant.h
+	include/moth_ui/flow/transitioning_layer.h
 	include/moth_ui/font_factory.h
 	include/moth_ui/graphics/blend_mode.h
 	include/moth_ui/graphics/iflipbook.h
@@ -76,7 +82,6 @@ set(PUBLIC_HEADERS
 	include/moth_ui/nodes/node_image.h
 	include/moth_ui/nodes/node_rect.h
 	include/moth_ui/nodes/node_text.h
-	include/moth_ui/nodes/widget.h
 	include/moth_ui/utils/color.h
 	include/moth_ui/utils/interp.h
 	include/moth_ui/utils/rect.h
@@ -90,6 +95,8 @@ set(PUBLIC_HEADERS
 	include/moth_ui/utils/transform.h
 	include/moth_ui/utils/vector_utils.h
 	include/moth_ui/version.h
+	include/moth_ui/widgets/ui_button.h
+	include/moth_ui/widgets/widget.h
 )
 set(SOURCES ${SOURCES}
 	src/animation/animation_clip_controller.cpp
@@ -101,6 +108,9 @@ set(SOURCES ${SOURCES}
 	src/animation/discrete_animation_track_controller.cpp
 	src/animation/keyframe.cpp
 	src/context.cpp
+	src/flow/flow.cpp
+	src/flow/flow_graph.cpp
+	src/flow/transitioning_layer.cpp
 	src/logger.cpp
 	src/font_factory.cpp
 	src/layers/layer.cpp
@@ -125,6 +135,8 @@ set(SOURCES ${SOURCES}
 	src/nodes/node_image.cpp
 	src/nodes/node_rect.cpp
 	src/nodes/node_text.cpp
+	src/widgets/ui_button.cpp
+	src/widgets/widget.cpp
 )
 
 find_package(nlohmann_json REQUIRED)

--- a/docs/flow_system_design.md
+++ b/docs/flow_system_design.md
@@ -1,0 +1,473 @@
+# Flow System — Design
+
+Status: design exploration, not yet implemented.
+
+Location: moth_ui, as an opt-in utility. Existing moth_ui users with their own layer/transition setup ignore the new headers and lose nothing; new users include `<moth_ui/flow/...>` and pick it up. The system has no moth_graphics dependency — the entire flow runtime, layer bases, and supporting widgets are pure moth_ui.
+
+## Goal
+
+A reusable navigation system for moth_ui-based applications. Apps define a graph of layers (screens and overlays) and transitions between them. The framework runs the transitions — playing animations, mutating the layer stack, sequencing side effects — so that application code stays focused on the layer's own logic, not on plumbing.
+
+The long-term goal is a visual editor that lets a designer build the flow graph (layers + transitions + button bindings) without writing code. This design treats that editor as the eventual primary consumer of the data model — every choice should keep the graph declarative, serialisable, and statically validatable where possible.
+
+## What the framework provides today, conceptually
+
+Scorched_moth's `src/flow/` and `src/layers/ui_layer.{h,cpp}` already contain ~250 lines of working flow infrastructure that we intend to lift and generalise:
+
+- A phase state machine (Idle / OutAnimating / InAnimating) coordinating transitions between two layers.
+- Deferred push/pop queues drained at the start of each `Tick`, so callers can mutate the stack from inside event handlers or `Update` without invalidating LayerStack iterators.
+- Overlay-vs-screen distinction with a "current screen" slot and an overlay vector layered on top.
+- A double-pop guard (`m_exitingOverlays`) preventing a rapid second `PopOverlay` from restarting an out-animation.
+- A clip-driven base layer that loads a `.mothui` layout, plays `transition_in` / `transition_out` clips, and converts the layer-wide `EventAnimationStopped` event into a `done()` callback firing.
+- Input gating via an `m_active` flag so layers don't receive events during transitions.
+
+The current code conflates screen identity (`enum class Screen { Title, Game }`), the layer factory (`CreateLayerFor` in `flow.cpp`), and the transition mechanics. The redesign pulls those apart: the framework owns the mechanics, the application owns the identities and factories, and the relationships between layers move into a serialisable graph.
+
+Scorched_moth also defines a `UIButton` widget (a moth_ui `Widget<T>` CRTP subclass) that exposes a click action. That widget moves into moth_ui alongside the flow system as a generally useful opt-in primitive — see "Buttons and the IClickable interface" below.
+
+## Core model
+
+### FlowGraph
+
+The serialisable artifact. An app loads a graph at startup, hands it to a `Flow` runtime, and from that point on, the graph drives navigation.
+
+```
+FlowGraph {
+    initial:   LayerId
+    policy:    GraphPolicy
+    layers:    LayerSpec[]
+}
+
+GraphPolicy {
+    onReentry: Reject | Queue | Coalesce   # default Queue depth 1
+    actionTimeoutMs: int                   # default several seconds, framework default
+}
+```
+
+### LayerSpec
+
+One node in the graph. Carries everything the runtime needs to construct and animate this layer, plus the outgoing transitions originating from it.
+
+```
+LayerSpec {
+    id:               LayerId          # unique within graph, e.g. "title", "game", "pause"
+    factory:          string | null    # name of an app-registered factory; null → default
+    layout:           string | null    # path to .mothui, consumed by default factory
+    kind:             Screen | Overlay
+    modality:         Modal | Passthrough   # overlays only; controls input/update of layers below
+    construction:     Fresh | Cached        # rebuild on entry, or preserve instance across visits
+    defaultOutClip:   string                # fallback used when a transition doesn't override
+    defaultInClip:    string                # fallback used when a transition doesn't override
+    transitions:      TransitionSpec[]      # outgoing edges from this layer
+}
+```
+
+Transitions are nested under their source layer rather than living in a flat list with a `from` field. Rationale:
+
+- Designers think of transitions as "from this screen I can go to..." — the JSON structure should mirror that.
+- The editor's natural per-layer card representation maps directly to nested transitions.
+- Lookup at runtime is cheaper: resolving "what does this button do here" walks `currentLayer.transitions` instead of filtering the whole transition table by `from == current`.
+- Validation can attribute errors to a specific source layer naturally.
+
+The trade-off: cross-cutting transitions (e.g., "from any layer, Esc → settings overlay") become awkward; you have to repeat the entry on every applicable layer. The editor handles that as authoring sugar (multi-select or a "global transitions" panel that expands on save). The runtime stays simple.
+
+### TransitionSpec
+
+One outgoing edge. Locally addressable as `"layerId.transitionId"`.
+
+```
+TransitionSpec {
+    id:        string              # local to parent layer; readable as "title.play"
+    to:        LayerId | "<back>"  # "<back>" pops the topmost overlay
+    kind:      Replace | Push | Pop
+    outClip:   string | null       # null → parent layer's defaultOutClip
+    inClip:    string | null       # null → target layer's defaultInClip
+    trigger:   TriggerSpec
+    onStart:   ActionRef[]         # side effects, see "Side effects" below
+    onMidpoint:ActionRef[]
+    onComplete:ActionRef[]
+}
+```
+
+The clip names are owned by the source-side transition. A transition's `inClip` therefore references a clip defined on the *target* layer's layout. This is a deliberate asymmetry: the choice of *which* in-clip to play is a property of the edge (the visual moment), not a property of the target layer in general. The target's `defaultInClip` is the fallback for transitions that don't care.
+
+The graph loader can validate `inClip` references at load time by reading the target's layout — fail loudly if a referenced clip doesn't exist. The editor can drive the same validation interactively (the inClip dropdown enumerates the target layout's clips).
+
+### TriggerSpec
+
+A discriminated union describing how a transition is initiated:
+
+```
+TriggerSpec =
+  | { type: "button", id: string }       # named UIButton in the source layer's layout
+  | { type: "key",    key: KeyId }       # key event while source is active
+  | { type: "event",  name: string }     # programmatic; layer code calls flow.Emit(name)
+  | { type: "auto",   afterMs: int }     # fires N ms after the layer enters
+```
+
+Button and key are the editor-friendly triggers a designer wires up directly. `event` is the escape hatch for things only C++ knows about (a match ending, an auth flow returning). `auto` covers splash → title style flows.
+
+Future enhancement: change `trigger: T` to `triggers: T[]` so one transition can be bound to both a button click and a key press without duplication.
+
+### Transition kinds
+
+Replace, Push, and Pop share one pipeline; they differ only in the stack-mutation step.
+
+| kind    | OutAnimating               | Stack mutation                 | InAnimating              |
+|---------|----------------------------|--------------------------------|--------------------------|
+| Replace | source.TransitionOut       | Remove source, push target     | target.TransitionIn      |
+| Push    | (skipped — source stays)   | Push target                    | target.TransitionIn      |
+| Pop     | source.TransitionOut       | Remove source                  | (skipped, no target)     |
+
+A `Replace` from inside an overlay back to a root screen (e.g., pause-menu Quit → Title) is expressed in JSON as a single `kind: replace` on the pause layer. The runtime is responsible for popping any overlays above the root before performing the replace; designers don't author intermediate pops.
+
+## Layer-side contract
+
+The framework depends only on a thin contract. Layouts and clips are one implementation; code-driven layers are another. Both implement the same interface.
+
+```cpp
+class ITransitionParticipant {
+public:
+    virtual void OnEnter() {}
+    virtual void OnExit()  {}
+
+    // tag is an opaque string. A clip-driven layer interprets it as a clip
+    // name. A code-driven layer interprets it however it likes. The Flow
+    // doesn't care; it just calls these and waits for done().
+    virtual void TransitionIn (std::string_view tag, std::function<void()> done) = 0;
+    virtual void TransitionOut(std::string_view tag, std::function<void()> done) = 0;
+};
+```
+
+Two concrete bases will ship in moth_ui:
+
+```cpp
+// .mothui-backed: tag is a clip name; HasAnimation → SetAnimation → wait for
+// EventAnimationStopped → done(). Handles button-binding and key-binding
+// installation from the graph automatically in OnEnter via IClickable lookups.
+class TransitioningLayer : public moth_ui::Layer,
+                            public ITransitionParticipant { ... };
+
+// Code-driven: subclass overrides TransitionIn/Out, drives its own animation,
+// calls done() when finished. No layout required.
+class CodeDrivenLayer : public moth_ui::Layer,
+                        public ITransitionParticipant { ... };
+```
+
+The `tag` parameter is the central design point. Because it's just a string, both implementations participate in exactly the same flow. A `TransitioningLayer` interprets the tag as a moth_ui clip name and looks it up on its loaded layout. A `CodeDrivenLayer` switches on the tag string to pick which animation routine to run. Neither tells the framework anything about its internals.
+
+A layer with no meaningful transition is a degenerate case: it inherits the default `TransitionIn`/`Out` that immediately fires `done()`. This is the right behaviour for debug overlays, instant-cut transitions, and toast notifications.
+
+### Layout-backed layer example
+
+```cpp
+// Pure pass-through. The layout has buttons "btn_resume" and "btn_quit", and
+// the graph's pause-layer JSON has transitions whose triggers reference those
+// button ids. TransitioningLayer's OnEnter walks the graph's transitions and
+// installs ClickActions on the matching UIButtons automatically. No custom
+// logic in this subclass; in fact, no subclass is needed at all if the layer
+// is purely graph-driven — see "When to subclass".
+class PauseLayer : public moth_graphics::flow::TransitioningLayer {
+public:
+    using TransitioningLayer::TransitioningLayer;
+};
+```
+
+### Code-driven layer example
+
+```cpp
+class TitleSplashLayer : public moth_graphics::flow::CodeDrivenLayer {
+public:
+    void TransitionIn(std::string_view tag, std::function<void()> done) override {
+        if (tag == "fast_fade") {
+            m_fadeMs = 200;
+        } else {
+            m_fadeMs = 800;
+        }
+        m_fadeStart = NowMs();
+        m_fadeDone = std::move(done);
+    }
+
+    void TransitionOut(std::string_view tag, std::function<void()> done) override {
+        // Just snap; this layer doesn't have an exit animation.
+        done();
+    }
+
+    void Update(uint32_t ticks) override {
+        if (m_fadeDone && (NowMs() - m_fadeStart) >= m_fadeMs) {
+            auto cb = std::move(m_fadeDone);
+            cb();
+        }
+    }
+
+    void Draw() override {
+        float const alpha = ComputeAlpha();
+        // Subclass-owned ad-hoc drawing — no .mothui layout, no clips.
+        DrawSplashImage(alpha);
+    }
+};
+```
+
+### When to subclass
+
+Most overlays and simple screens shouldn't need a C++ subclass at all — they're a `.mothui` layout plus a few transitions in the graph. `TransitioningLayer` is the default factory; the LayerSpec just needs a `layout` path.
+
+A C++ subclass is needed when a layer has state or logic the graph can't express:
+
+- It owns or interacts with a long-lived app object (e.g., `GameLayer` reads from `Match`).
+- It emits programmatic events back into the flow (`flow.Emit("match_ended")`).
+- It draws or animates outside the .mothui layout system (then prefer `CodeDrivenLayer`).
+
+In the scorched_moth example, of four current layers, three (`TitleLayer`, `PauseMenuLayer`, `GameOverLayer`) can become plain JSON entries with no C++ subclass. Only `GameLayer` remains a subclass.
+
+## Buttons and the `IClickable` interface
+
+moth_ui has no native button widget; `nodes/widget.h` is a CRTP extension point for apps to define their own. The flow system needs to find clickable named nodes on a layout and attach click actions when a TransitionSpec's trigger is `{type: "button", id: "..."}`. Two coupled additions to moth_ui solve this:
+
+### `IClickable`
+
+A minimal abstract interface in moth_ui's public surface:
+
+```cpp
+namespace moth_ui {
+    class IClickable {
+    public:
+        virtual ~IClickable() = default;
+        virtual void SetClickAction(std::function<void()> action) = 0;
+    };
+}
+```
+
+The flow runtime locates buttons via `dynamic_cast<IClickable*>(node)` when walking a layout. Whatever the widget actually is — moth_ui's bundled `UIButton`, an app's custom button with hover/sound/animation, an app's image-with-click — it works as long as it implements `IClickable`. The framework never knows or cares about the concrete type.
+
+### `UIButton` (moved from scorched_moth)
+
+A `Widget<UIButton>`-based clickable button shipped in moth_ui as an opt-in convenience. Apps that just want a button drop one into their layout and reference it from the flow graph. Apps that need richer interaction (hover audio, focus rings, controller navigation) provide their own widget that implements `IClickable` and ignore the bundled `UIButton` entirely.
+
+This is the same pattern moth_ui already follows with `Widget<T>` itself — opt-in primitives that cover the common case without locking out custom implementations.
+
+### Why this matters for the design
+
+`TransitioningLayer::OnEnter` becomes app-subclass-free for trivial screens. It walks the graph's transitions for this layer, and for each `{type: "button"}` trigger does:
+
+```cpp
+if (auto* clickable = dynamic_cast<IClickable*>(m_uiRoot->FindChild(triggerSpec.id).get())) {
+    clickable->SetClickAction([this, transitionId]{ m_flow.Trigger(transitionId); });
+}
+```
+
+A title screen with `Play` and `Quit` buttons is now zero C++ — the layout uses `UIButton` (or any app widget implementing `IClickable`), the graph JSON wires the buttons to transitions, and the framework does the rest.
+
+## The Flow runtime
+
+```cpp
+namespace moth_ui::flow {
+
+class Flow {
+public:
+    Flow(LayerStack&, Context&, FlowGraph);
+
+    // Layers whose LayerSpec has factory == null are constructed by the default
+    // factory (which builds a TransitioningLayer from layout). Custom factories
+    // get registered by name.
+    void RegisterFactory(std::string name, LayerFactory);
+
+    // Same registry mechanism for side-effect actions.
+    void RegisterAction(std::string name, Action);
+
+    // Programmatic trigger of a specific transition by qualified id.
+    void Trigger(std::string_view qualifiedId);   // "title.play"
+
+    // Programmatic emission of a named event. The Flow resolves this against
+    // the currently-active layer's TriggerSpec list.
+    void Emit(std::string_view eventName);
+
+    // Pumped from the application's main loop.
+    void Tick();
+};
+
+}
+```
+
+The `Flow` constructor takes only moth_ui types: a `LayerStack` to mutate, a `Context` to pass to layer factories, and the loaded `FlowGraph`. It deliberately does **not** take a `Window` or any other graphics-backend reference — apps that need backend access in their layer subclasses get it through their own factory closures, not through the framework. This keeps `Flow` framework-agnostic and embeddable in the eventual editor process without dragging a window dependency in.
+
+The `Flow` has no knowledge of any specific layer or screen — those are addressed by string. The application registers the factories and actions that turn strings into behaviour. The graph references both by name. This is the contract surface between code and visual editor: when designers ask for new options, the engineer adds a factory or an action and rebuilds; nothing in the editor changes structurally.
+
+## Transition state machine
+
+Once a trigger fires, the runtime walks a fixed sequence of phases. Each phase can be synchronous (`done()` fires immediately) or asynchronous (the framework waits for an explicit callback).
+
+```
+Idle
+  └─ Trigger(t) accepted
+OnStart        ─── run t.onStart actions sequentially ───────────────┐
+  └─ done                                                             │
+OutAnimating   ─── source.TransitionOut(outClip, done)               │  each phase can be
+  └─ done                                                             │  async; runtime waits
+(stack mutation per t.kind)                                           │  for done() before
+OnMidpoint     ─── run t.onMidpoint actions sequentially ─────────────│  advancing
+  └─ done                                                             │
+InAnimating    ─── target.TransitionIn(inClip, done)                  │
+  └─ done                                                             │
+OnComplete     ─── run t.onComplete actions sequentially ─────────────│
+  └─ done                                                             │
+Idle ─────────────────────────────────────────────────────────────────┘
+```
+
+Stack mutation happens *before* OnMidpoint, not after. This means actions in OnMidpoint can reach the just-constructed target layer if they want (to inject pending state into it, for instance). For the common case — `session.NewMatch()` touching a long-lived `Match` object — the ordering doesn't matter, but the "mutation first" choice is the more useful default for cases where it does.
+
+For `Push` transitions, `OutAnimating` is skipped. For `Pop`, `InAnimating` is skipped. OnStart, OnMidpoint, and OnComplete still fire in both cases; OnMidpoint is the natural place to release per-overlay resources during a pop.
+
+### Re-entry policy
+
+If a `Trigger()` arrives while the machine is non-Idle, the policy field decides:
+
+- **Reject**: log and drop. Current scorched_moth behaviour.
+- **Queue** (depth 1): hold the request, apply it when the current transition reaches Idle. Default.
+- **Coalesce**: last-wins; replace any queued request with the new one.
+
+Queue depth >1 isn't supported in v1; if a designer needs that, they almost certainly want a different feature (a stack of forward navigations with "go back" semantics, e.g.).
+
+## Side effects (the action registry)
+
+Side effects are application code triggered from points in the state machine. They are referenced from JSON by name and registered in C++ by the application.
+
+```cpp
+using Action = std::function<void(std::function<void()> done)>;
+
+flow.RegisterAction("session.NewMatch",
+    [&session](std::function<void()> done) {
+        session.NewMatch(util::Rng::RandomSeed());
+        done();
+    });
+
+flow.RegisterAction("assets.PreloadGame",
+    [&loader](std::function<void()> done) {
+        loader.LoadGroup("game", std::move(done));   // genuinely async
+    });
+```
+
+Actions are always treated as async by the runtime; sync actions just call `done()` immediately. This keeps one code path and lets long-running side effects (asset loading, network calls) slot in naturally without special handling.
+
+When multiple actions are listed on the same hook, they run **sequentially in JSON order**. Designer-authored ordering is preserved, and any one action can take its time without others jumping ahead.
+
+### Where side effects live in the lifecycle
+
+| Hook        | Fires                                                   | Typical use                                        |
+|-------------|---------------------------------------------------------|----------------------------------------------------|
+| onStart     | Before source's TransitionOut begins                    | Fade music out; freeze a simulation                |
+| onMidpoint  | After stack mutation, before target's TransitionIn      | Reset model state visible during target's fade-in  |
+| onComplete  | After target's TransitionIn ends                        | Resume music; start post-entry timers              |
+
+The midpoint slot is the design payoff: state changes that need to be invisible to the player happen while neither the old nor the new view is animating. The match-reset example — `session.NewMatch()` between Title → Game — lets the new match be visible the moment GameLayer's fade-in starts, with no flash of the old state.
+
+### Parameters — punted
+
+Actions are parameterless in v1. `session.NewMatch` reads its seed from app-side state (a "pending session config" or similar set up before triggering). Adding parameter passing through the JSON would require either:
+
+1. Per-action parameter schemas (so the editor can render UI for them).
+2. Opaque JSON blobs (no editor support).
+3. Stringly-typed action factories (`"session.NewMatch[seed=random]"`).
+
+None of these is right for v1. The editor isn't here yet, and app-side state is sufficient. Revisit once the editor lands: option 1 with per-action schemas is the right long-term answer but is a meaningful authoring-UI investment.
+
+### Error handling and timeouts
+
+If an action's `done()` is never called, the transition stalls. The framework enforces a per-action timeout (configured in `GraphPolicy.actionTimeoutMs`) and force-advances on expiry with a loud log. The same policy applies to layers' `TransitionIn`/`Out` callbacks. Missing callbacks are almost always bugs and the runtime must not silently swallow them.
+
+If an action throws, the framework logs and force-advances. Transitions in flight do not get rolled back; the system is forward-only.
+
+### Cancellation — deliberately not supported
+
+Once a transition starts, it commits. "Conditional navigation" (e.g., confirm-before-quit) is the app's responsibility: the title's quit button shows a confirmation overlay, and only that overlay's OK button calls `Trigger("title.quit")`. Adding conditional cancellation to the graph would turn the runtime into a workflow engine, which is a different and much bigger product.
+
+Similarly, actions don't return values back into the graph. If the C++ side needs to decide between transitions based on some outcome, it decides in code and triggers a different transition.
+
+## Modality
+
+Overlays carry a `modality` field that controls how the layers below them behave while the overlay is up:
+
+- `Modal`: `moth_ui::LayerStack` short-circuits event delivery and `Update` calls to layers beneath this one. The pause menu doesn't need a manual `m_paused` flag in `GameLayer` — being covered by a modal overlay is what pauses the game.
+- `Passthrough`: layers beneath continue to update and receive non-handled input. Useful for HUD overlays, debug panels.
+
+The `m_actionTriggered` double-click guard recurring in scorched_moth's overlay subclasses is subsumed by the framework's "transition already in progress" guard: once a button click triggers a transition, the runtime is non-Idle, and further clicks are rejected (or queued, per policy).
+
+Implementation note: modal-skip is a `moth_ui::LayerStack` semantic extension, not purely a flow-system addition. The flag the flow system reads (`LayerSpec.modality`) maps to a property the LayerStack honours during its update/event-dispatch loop. The LayerStack change is the foundational dependency that lands before the flow system itself.
+
+## Consequences for application code
+
+The scorched_moth example, projected against the new system:
+
+- `Flow` class in `src/flow/` disappears in favour of `moth_ui::flow::Flow` constructed from a JSON-loaded `FlowGraph`.
+- `enum class Screen` disappears; layers are identified by string id in the graph.
+- `IFlowLayer` disappears (subsumed by `ITransitionParticipant`).
+- `UILayer` disappears (subsumed by `TransitioningLayer`).
+- `UIButton` moves to moth_ui as an opt-in widget; scorched_moth includes the moth_ui header instead of carrying its own copy.
+- `TitleLayer`, `PauseMenuLayer`, `GameOverLayer` disappear as C++ classes; they become layer entries in the graph JSON.
+- `GameLayer` remains as a C++ subclass because it owns and renders the game world. It becomes a view-only object: `Match` is owned externally (by an `Application`-level `Session` object or similar), and `GameLayer` reads from it. Replays don't reconstruct `GameLayer` — they call `Session::NewMatch()` from an `onMidpoint` action on the relevant transition and let the existing `GameLayer` re-enter via `OnEnter`.
+- `m_actionTriggered` guards, manual `PushOverlay`/`PopOverlay` calls, lambda chains threaded through constructors, and the per-layer `m_paused` flag all disappear.
+
+The remaining C++ surface for the app is: register factories, register actions, load the graph, pump `Tick`. Everything else is data.
+
+## Public API additions to moth_ui
+
+This design introduces several new public headers in moth_ui. They're all opt-in — including none of them leaves existing moth_ui users unaffected.
+
+- `moth_ui/flow/flow.h` — the `Flow` runtime.
+- `moth_ui/flow/flow_graph.h` — `FlowGraph`, `LayerSpec`, `TransitionSpec`, `TriggerSpec` and JSON loaders.
+- `moth_ui/flow/transition_participant.h` — the `ITransitionParticipant` interface.
+- `moth_ui/flow/transitioning_layer.h` — the `.mothui`-backed layer base.
+- `moth_ui/flow/code_driven_layer.h` — the code-driven layer base.
+- `moth_ui/iclickable.h` — the `IClickable` interface (top-level in moth_ui; not under flow/, since custom widgets that aren't graph-driven can also benefit).
+- `moth_ui/nodes/ui_button.h` — the bundled `UIButton` widget that implements `IClickable`.
+
+The `moth_ui/flow/` subdirectory is a coherent unit; users can ignore it wholesale or pull in the pieces they want.
+
+## Editor implications (forward-looking)
+
+- Each LayerSpec is a card in a node diagram.
+- Each TransitionSpec is an arrow between two cards.
+- Each arrow exposes: a target dropdown (other layers); a kind dropdown; an out-clip dropdown (clips on source's layout); an in-clip dropdown (clips on target's layout); a trigger configurator; three lists (onStart/onMidpoint/onComplete) of action names from a dropdown populated by the app's registered actions.
+- The action registry is the contract surface between code and editor. Adding new options means adding actions in C++ and rebuilding; the editor's UI is data-driven from the registry.
+- Button-trigger dropdowns enumerate layout node ids whose factory-registered type implements `IClickable`. The editor learns about clickable widget types via the same `NodeFactory` registration `Widget<T>` uses today.
+- For layout-backed layers the editor can instantiate the actual `TransitioningLayer` and play transitions live in-tool. Code-driven layers can't preview at design time; the editor should show a stubbed placeholder and be honest about the limitation.
+
+To keep that editor possible, the runtime needs to be embeddable in the editor process. The flow system's moth_ui-only dependency footprint already supports this: the editor pulls in moth_ui (it does today) and gets the flow runtime for free, with no moth_graphics window/graphics dragged in. Two further things to watch for during implementation: avoid `main()`-level singletons (the current scorched_moth code already avoids this), and don't bake global logger configuration into the Flow itself.
+
+## Validation surface (at graph-load time)
+
+A graph integrity check runs once at load and reports all problems before the first frame:
+
+- Every `to` field references a defined layer (or `"<back>"`).
+- Every `outClip` references a clip on the parent layer's layout (skipped for code-driven layers).
+- Every `inClip` references a clip on the target layer's layout (skipped for code-driven layers).
+- Every `trigger.button.id` references a node id present on the parent layer's layout whose registered type implements `IClickable`.
+- Every `factory` references a registered factory.
+- Every `ActionRef` references a registered action.
+- The `initial` layer exists.
+- No `Push` transition targets a `Screen`-kind layer (overlays can only push overlays).
+- No `Pop` transition has a non-`"<back>"` target.
+
+The validator should report **all** failures at once, not stop on the first — load-time bugs in big graphs are otherwise tedious to fix.
+
+## Open questions deferred
+
+- **Wildcard transitions (`from: "*"`).** Designers will eventually want "Esc from any screen → settings overlay." Authoring sugar in the editor can expand to per-layer entries on save in v1; revisit a true wildcard in the runtime if the duplication becomes painful.
+- **Multi-trigger transitions.** `triggers: T[]` instead of `trigger: T`. Mechanically easy; defer until the editor exists and the authoring pain is observable.
+- **Action parameters.** Per-action schemas plus editor UI; revisit alongside the editor.
+- **Cached layer construction lifecycle.** When a `construction: Cached` layer is evicted (memory pressure, debug action), what happens? v1 keeps cached layers forever; revisit if memory matters.
+- **Auto-trigger pause semantics.** A layer with an `auto` trigger has its timer ticking while it's the topmost. What happens when a modal overlay covers it? Default: pause the timer (consistent with "modal blocks updates below"). Document but verify in implementation.
+- **History / back-stack.** No first-class history beyond the overlay stack. If apps need a "go back" stack across screen replaces, that's a future feature, not v1.
+
+## Out of scope for the first cut
+
+- Wildcard transitions.
+- Multi-trigger transitions.
+- Action parameters.
+- Auto triggers with `afterMs` countdown UI.
+- The visual editor itself.
+- History / back-stack across screens.
+- Cancellation, conditional flow, return values from actions.
+- Cross-process / hot-reload of graphs.
+
+Everything not on this list is v1.

--- a/docs/flow_system_design.md
+++ b/docs/flow_system_design.md
@@ -1,35 +1,73 @@
 # Flow System — Design
 
-Status: implemented (PR #147). The runtime, layer bases, JSON loader, and bundled `UIButton` widget have all landed under `moth_ui/flow/` and `moth_ui/widgets/`. This document is the design-of-record; concrete naming or behaviour drifts should be reconciled against the headers.
+Status: implemented (PR #147). The runtime, layer bases, JSON loader, and bundled
+`UIButton` widget have all landed under `moth_ui/flow/` and `moth_ui/widgets/`. This
+document is the **design-of-record** — it captures the rationale (why transitions
+nest under layers, why the stack mutates before the midpoint, the string-`tag`
+contract, deferred editor scope). It is written partly in pre-implementation tense
+and describes scorched_moth's *old* hand-rolled flow code as the thing being
+generalised; that code is gone now and scorched_moth consumes `moth_ui::flow`
+directly.
 
-Location: moth_ui, as an opt-in utility. Existing moth_ui users with their own layer/transition setup ignore the new headers and lose nothing; new users include `<moth_ui/flow/...>` and pick it up. The system has no moth_graphics dependency — the entire flow runtime, layer bases, and supporting widgets are pure moth_ui.
+**For a consumer-facing how-to** — standing up a `Flow`, the real API surface,
+building a graph, and the gotchas — see
+[`flow_system_guide.md`](flow_system_guide.md). Where this doc and the guide disagree
+on concrete API, the guide and the headers win.
+
+Location: moth_ui, as an opt-in utility. Existing moth_ui users with their own
+layer/transition setup ignore the new headers and lose nothing; new users include
+`<moth_ui/flow/...>` and pick it up. The system has no moth_graphics dependency — the
+entire flow runtime, layer bases, and supporting widgets are pure moth_ui.
 
 ## Goal
 
-A reusable navigation system for moth_ui-based applications. Apps define a graph of layers (screens and overlays) and transitions between them. The framework runs the transitions — playing animations, mutating the layer stack, sequencing side effects — so that application code stays focused on the layer's own logic, not on plumbing.
+A reusable navigation system for moth_ui-based applications. Apps define a graph of
+layers (screens and overlays) and transitions between them. The framework runs the
+transitions — playing animations, mutating the layer stack, sequencing side effects —
+so that application code stays focused on the layer's own logic, not on plumbing.
 
-The long-term goal is a visual editor that lets a designer build the flow graph (layers + transitions + button bindings) without writing code. This design treats that editor as the eventual primary consumer of the data model — every choice should keep the graph declarative, serialisable, and statically validatable where possible.
+The long-term goal is a visual editor that lets a designer build the flow graph
+(layers + transitions + button bindings) without writing code. This design treats
+that editor as the eventual primary consumer of the data model — every choice should
+keep the graph declarative, serialisable, and statically validatable where possible.
 
 ## What the framework provides today, conceptually
 
-Scorched_moth's `src/flow/` and `src/layers/ui_layer.{h,cpp}` already contain ~250 lines of working flow infrastructure that we intend to lift and generalise:
+Scorched_moth's `src/flow/` and `src/layers/ui_layer.{h,cpp}` already contain ~250
+lines of working flow infrastructure that we intend to lift and generalise:
 
-- A phase state machine (Idle / OutAnimating / InAnimating) coordinating transitions between two layers.
-- Deferred push/pop queues drained at the start of each `Tick`, so callers can mutate the stack from inside event handlers or `Update` without invalidating LayerStack iterators.
-- Overlay-vs-screen distinction with a "current screen" slot and an overlay vector layered on top.
-- A double-pop guard (`m_exitingOverlays`) preventing a rapid second `PopOverlay` from restarting an out-animation.
-- A clip-driven base layer that loads a `.mothui` layout, plays `transition_in` / `transition_out` clips, and converts the layer-wide `EventAnimationStopped` event into a `done()` callback firing.
-- Input gating via an `m_active` flag so layers don't receive events during transitions.
+- A phase state machine (Idle / OutAnimating / InAnimating) coordinating transitions
+  between two layers.
+- Deferred push/pop queues drained at the start of each `Tick`, so callers can mutate
+  the stack from inside event handlers or `Update` without invalidating LayerStack
+  iterators.
+- Overlay-vs-screen distinction with a "current screen" slot and an overlay vector
+  layered on top.
+- A double-pop guard (`m_exitingOverlays`) preventing a rapid second `PopOverlay`
+  from restarting an out-animation.
+- A clip-driven base layer that loads a `.mothui` layout, plays `transition_in` /
+  `transition_out` clips, and converts the layer-wide `EventAnimationStopped` event
+  into a `done()` callback firing.
+- Input gating via an `m_active` flag so layers don't receive events during
+  transitions.
 
-The current code conflates screen identity (`enum class Screen { Title, Game }`), the layer factory (`CreateLayerFor` in `flow.cpp`), and the transition mechanics. The redesign pulls those apart: the framework owns the mechanics, the application owns the identities and factories, and the relationships between layers move into a serialisable graph.
+The current code conflates screen identity (`enum class Screen { Title, Game }`), the
+layer factory (`CreateLayerFor` in `flow.cpp`), and the transition mechanics. The
+redesign pulls those apart: the framework owns the mechanics, the application owns
+the identities and factories, and the relationships between layers move into a
+serialisable graph.
 
-Scorched_moth also defines a `UIButton` widget (a moth_ui `Widget<T>` CRTP subclass) that exposes a click action. That widget moves into moth_ui alongside the flow system as a generally useful opt-in primitive — see "Buttons and the IClickable interface" below.
+Scorched_moth also defines a `UIButton` widget (a moth_ui `Widget<T>` CRTP subclass)
+that exposes a click action. That widget moves into moth_ui alongside the flow system
+as a generally useful opt-in primitive — see "Buttons and the IClickable interface"
+below.
 
 ## Core model
 
 ### FlowGraph
 
-The serialisable artifact. An app loads a graph at startup, hands it to a `Flow` runtime, and from that point on, the graph drives navigation.
+The serialisable artifact. An app loads a graph at startup, hands it to a `Flow`
+runtime, and from that point on, the graph drives navigation.
 
 ```text
 FlowGraph {
@@ -46,7 +84,8 @@ GraphPolicy {
 
 ### LayerSpec
 
-One node in the graph. Carries everything the runtime needs to construct and animate this layer, plus the outgoing transitions originating from it.
+One node in the graph. Carries everything the runtime needs to construct and animate
+this layer, plus the outgoing transitions originating from it.
 
 ```text
 LayerSpec {
@@ -62,14 +101,22 @@ LayerSpec {
 }
 ```
 
-Transitions are nested under their source layer rather than living in a flat list with a `from` field. Rationale:
+Transitions are nested under their source layer rather than living in a flat list
+with a `from` field. Rationale:
 
-- Designers think of transitions as "from this screen I can go to..." — the JSON structure should mirror that.
-- The editor's natural per-layer card representation maps directly to nested transitions.
-- Lookup at runtime is cheaper: resolving "what does this button do here" walks `currentLayer.transitions` instead of filtering the whole transition table by `from == current`.
+- Designers think of transitions as "from this screen I can go to..." — the JSON
+  structure should mirror that.
+- The editor's natural per-layer card representation maps directly to nested
+  transitions.
+- Lookup at runtime is cheaper: resolving "what does this button do here" walks
+  `currentLayer.transitions` instead of filtering the whole transition table by `from
+  == current`.
 - Validation can attribute errors to a specific source layer naturally.
 
-The trade-off: cross-cutting transitions (e.g., "from any layer, Esc → settings overlay") become awkward; you have to repeat the entry on every applicable layer. The editor handles that as authoring sugar (multi-select or a "global transitions" panel that expands on save). The runtime stays simple.
+The trade-off: cross-cutting transitions (e.g., "from any layer, Esc → settings
+overlay") become awkward; you have to repeat the entry on every applicable layer. The
+editor handles that as authoring sugar (multi-select or a "global transitions" panel
+that expands on save). The runtime stays simple.
 
 ### TransitionSpec
 
@@ -89,9 +136,16 @@ TransitionSpec {
 }
 ```
 
-The clip names are owned by the source-side transition. A transition's `inClip` therefore references a clip defined on the *target* layer's layout. This is a deliberate asymmetry: the choice of *which* in-clip to play is a property of the edge (the visual moment), not a property of the target layer in general. The target's `defaultInClip` is the fallback for transitions that don't care.
+The clip names are owned by the source-side transition. A transition's `inClip`
+therefore references a clip defined on the *target* layer's layout. This is a
+deliberate asymmetry: the choice of *which* in-clip to play is a property of the edge
+(the visual moment), not a property of the target layer in general. The target's
+`defaultInClip` is the fallback for transitions that don't care.
 
-The graph loader can validate `inClip` references at load time by reading the target's layout — fail loudly if a referenced clip doesn't exist. The editor can drive the same validation interactively (the inClip dropdown enumerates the target layout's clips).
+The graph loader can validate `inClip` references at load time by reading the
+target's layout — fail loudly if a referenced clip doesn't exist. The editor can
+drive the same validation interactively (the inClip dropdown enumerates the target
+layout's clips).
 
 ### TriggerSpec
 
@@ -105,13 +159,17 @@ TriggerSpec =
   | { type: "auto",   afterMs: int }     # fires N ms after the layer enters
 ```
 
-Button and key are the editor-friendly triggers a designer wires up directly. `event` is the escape hatch for things only C++ knows about (a match ending, an auth flow returning). `auto` covers splash → title style flows.
+Button and key are the editor-friendly triggers a designer wires up directly. `event`
+is the escape hatch for things only C++ knows about (a match ending, an auth flow
+returning). `auto` covers splash → title style flows.
 
-Future enhancement: change `trigger: T` to `triggers: T[]` so one transition can be bound to both a button click and a key press without duplication.
+Future enhancement: change `trigger: T` to `triggers: T[]` so one transition can be
+bound to both a button click and a key press without duplication.
 
 ### Transition kinds
 
-Replace, Push, and Pop share one pipeline; they differ only in the stack-mutation step.
+Replace, Push, and Pop share one pipeline; they differ only in the stack-mutation
+step.
 
 | kind    | OutAnimating               | Stack mutation                 | InAnimating              |
 |---------|----------------------------|--------------------------------|--------------------------|
@@ -119,11 +177,15 @@ Replace, Push, and Pop share one pipeline; they differ only in the stack-mutatio
 | Push    | (skipped — source stays)   | Push target                    | target.TransitionIn      |
 | Pop     | source.TransitionOut       | Remove source                  | (skipped, no target)     |
 
-A `Replace` from inside an overlay back to a root screen (e.g., pause-menu Quit → Title) is expressed in JSON as a single `kind: replace` on the pause layer. The runtime is responsible for popping any overlays above the root before performing the replace; designers don't author intermediate pops.
+A `Replace` from inside an overlay back to a root screen (e.g., pause-menu Quit →
+Title) is expressed in JSON as a single `kind: replace` on the pause layer. The
+runtime is responsible for popping any overlays above the root before performing the
+replace; designers don't author intermediate pops.
 
 ## Layer-side contract
 
-The framework depends only on a thin contract. Layouts and clips are one implementation; code-driven layers are another. Both implement the same interface.
+The framework depends only on a thin contract. Layouts and clips are one
+implementation; code-driven layers are another. Both implement the same interface.
 
 ```cpp
 class ITransitionParticipant {
@@ -154,9 +216,15 @@ class CodeDrivenLayer : public moth_ui::Layer,
                         public ITransitionParticipant { ... };
 ```
 
-The `tag` parameter is the central design point. Because it's just a string, both implementations participate in exactly the same flow. A `TransitioningLayer` interprets the tag as a moth_ui clip name and looks it up on its loaded layout. A `CodeDrivenLayer` switches on the tag string to pick which animation routine to run. Neither tells the framework anything about its internals.
+The `tag` parameter is the central design point. Because it's just a string, both
+implementations participate in exactly the same flow. A `TransitioningLayer`
+interprets the tag as a moth_ui clip name and looks it up on its loaded layout. A
+`CodeDrivenLayer` switches on the tag string to pick which animation routine to run.
+Neither tells the framework anything about its internals.
 
-A layer with no meaningful transition is a degenerate case: it inherits the default `TransitionIn`/`Out` that immediately fires `done()`. This is the right behaviour for debug overlays, instant-cut transitions, and toast notifications.
+A layer with no meaningful transition is a degenerate case: it inherits the default
+`TransitionIn`/`Out` that immediately fires `done()`. This is the right behaviour for
+debug overlays, instant-cut transitions, and toast notifications.
 
 ### Layout-backed layer example
 
@@ -210,19 +278,28 @@ public:
 
 ### When to subclass
 
-Most overlays and simple screens shouldn't need a C++ subclass at all — they're a `.mothui` layout plus a few transitions in the graph. `TransitioningLayer` is the default factory; the LayerSpec just needs a `layout` path.
+Most overlays and simple screens shouldn't need a C++ subclass at all — they're a
+`.mothui` layout plus a few transitions in the graph. `TransitioningLayer` is the
+default factory; the LayerSpec just needs a `layout` path.
 
 A C++ subclass is needed when a layer has state or logic the graph can't express:
 
-- It owns or interacts with a long-lived app object (e.g., `GameLayer` reads from `Match`).
+- It owns or interacts with a long-lived app object (e.g., `GameLayer` reads from
+  `Match`).
 - It emits programmatic events back into the flow (`flow.Emit("match_ended")`).
-- It draws or animates outside the .mothui layout system (then prefer `CodeDrivenLayer`).
+- It draws or animates outside the .mothui layout system (then prefer
+  `CodeDrivenLayer`).
 
-In the scorched_moth example, of four current layers, three (`TitleLayer`, `PauseMenuLayer`, `GameOverLayer`) can become plain JSON entries with no C++ subclass. Only `GameLayer` remains a subclass.
+In the scorched_moth example, of four current layers, three (`TitleLayer`,
+`PauseMenuLayer`, `GameOverLayer`) can become plain JSON entries with no C++
+subclass. Only `GameLayer` remains a subclass.
 
 ## Buttons and the `IClickable` interface
 
-moth_ui has no native button widget; `nodes/widget.h` is a CRTP extension point for apps to define their own. The flow system needs to find clickable named nodes on a layout and attach click actions when a TransitionSpec's trigger is `{type: "button", id: "..."}`. Two coupled additions to moth_ui solve this:
+moth_ui has no native button widget; `nodes/widget.h` is a CRTP extension point for
+apps to define their own. The flow system needs to find clickable named nodes on a
+layout and attach click actions when a TransitionSpec's trigger is `{type: "button",
+id: "..."}`. Two coupled additions to moth_ui solve this:
 
 ### `IClickable`
 
@@ -238,17 +315,27 @@ namespace moth_ui {
 }
 ```
 
-The flow runtime locates buttons via `dynamic_cast<IClickable*>(node)` when walking a layout. Whatever the widget actually is — moth_ui's bundled `UIButton`, an app's custom button with hover/sound/animation, an app's image-with-click — it works as long as it implements `IClickable`. The framework never knows or cares about the concrete type.
+The flow runtime locates buttons via `dynamic_cast<IClickable*>(node)` when walking a
+layout. Whatever the widget actually is — moth_ui's bundled `UIButton`, an app's
+custom button with hover/sound/animation, an app's image-with-click — it works as
+long as it implements `IClickable`. The framework never knows or cares about the
+concrete type.
 
 ### `UIButton` (moved from scorched_moth)
 
-A `Widget<UIButton>`-based clickable button shipped in moth_ui as an opt-in convenience. Apps that just want a button drop one into their layout and reference it from the flow graph. Apps that need richer interaction (hover audio, focus rings, controller navigation) provide their own widget that implements `IClickable` and ignore the bundled `UIButton` entirely.
+A `Widget<UIButton>`-based clickable button shipped in moth_ui as an opt-in
+convenience. Apps that just want a button drop one into their layout and reference it
+from the flow graph. Apps that need richer interaction (hover audio, focus rings,
+controller navigation) provide their own widget that implements `IClickable` and
+ignore the bundled `UIButton` entirely.
 
-This is the same pattern moth_ui already follows with `Widget<T>` itself — opt-in primitives that cover the common case without locking out custom implementations.
+This is the same pattern moth_ui already follows with `Widget<T>` itself — opt-in
+primitives that cover the common case without locking out custom implementations.
 
 ### Why this matters for the design
 
-`TransitioningLayer::OnEnter` becomes app-subclass-free for trivial screens. It walks the graph's transitions for this layer, and for each `{type: "button"}` trigger does:
+`TransitioningLayer::OnEnter` becomes app-subclass-free for trivial screens. It walks
+the graph's transitions for this layer, and for each `{type: "button"}` trigger does:
 
 ```cpp
 if (auto* clickable = dynamic_cast<IClickable*>(m_uiRoot->FindChild(triggerSpec.id).get())) {
@@ -256,7 +343,9 @@ if (auto* clickable = dynamic_cast<IClickable*>(m_uiRoot->FindChild(triggerSpec.
 }
 ```
 
-A title screen with `Play` and `Quit` buttons is now zero C++ — the layout uses `UIButton` (or any app widget implementing `IClickable`), the graph JSON wires the buttons to transitions, and the framework does the rest.
+A title screen with `Play` and `Quit` buttons is now zero C++ — the layout uses
+`UIButton` (or any app widget implementing `IClickable`), the graph JSON wires the
+buttons to transitions, and the framework does the rest.
 
 ## The Flow runtime
 
@@ -275,6 +364,10 @@ public:
     // Same registry mechanism for side-effect actions.
     void RegisterAction(std::string name, Action);
 
+    // Creates and pushes the initial layer. Call once, after all factories
+    // and actions are registered, before the first Tick.
+    void Start();
+
     // Programmatic trigger of a specific transition by qualified id.
     void Trigger(std::string_view qualifiedId);   // "title.play"
 
@@ -282,20 +375,35 @@ public:
     // the currently-active layer's TriggerSpec list.
     void Emit(std::string_view eventName);
 
-    // Pumped from the application's main loop.
-    void Tick();
+    // Pre-stack event filter — feed every event here before the LayerStack
+    // so key triggers get first look. Returns true if consumed.
+    bool OnEvent(Event const& event);
+
+    // Pumped from the application's main loop with elapsed milliseconds.
+    void Tick(uint32_t ticks);
 };
 
 }
 ```
 
-The `Flow` constructor takes only moth_ui types: a `LayerStack` to mutate, a `Context` to pass to layer factories, and the loaded `FlowGraph`. It deliberately does **not** take a `Window` or any other graphics-backend reference — apps that need backend access in their layer subclasses get it through their own factory closures, not through the framework. This keeps `Flow` framework-agnostic and embeddable in the eventual editor process without dragging a window dependency in.
+The `Flow` constructor takes only moth_ui types: a `LayerStack` to mutate, a
+`Context` to pass to layer factories, and the loaded `FlowGraph`. It deliberately
+does **not** take a `Window` or any other graphics-backend reference — apps that need
+backend access in their layer subclasses get it through their own factory closures,
+not through the framework. This keeps `Flow` framework-agnostic and embeddable in the
+eventual editor process without dragging a window dependency in.
 
-The `Flow` has no knowledge of any specific layer or screen — those are addressed by string. The application registers the factories and actions that turn strings into behaviour. The graph references both by name. This is the contract surface between code and visual editor: when designers ask for new options, the engineer adds a factory or an action and rebuilds; nothing in the editor changes structurally.
+The `Flow` has no knowledge of any specific layer or screen — those are addressed by
+string. The application registers the factories and actions that turn strings into
+behaviour. The graph references both by name. This is the contract surface between
+code and visual editor: when designers ask for new options, the engineer adds a
+factory or an action and rebuilds; nothing in the editor changes structurally.
 
 ## Transition state machine
 
-Once a trigger fires, the runtime walks a fixed sequence of phases. Each phase can be synchronous (`done()` fires immediately) or asynchronous (the framework waits for an explicit callback).
+Once a trigger fires, the runtime walks a fixed sequence of phases. Each phase can be
+synchronous (`done()` fires immediately) or asynchronous (the framework waits for an
+explicit callback).
 
 ```text
 Idle
@@ -314,23 +422,33 @@ OnComplete     ─── run t.onComplete actions sequentially ─────�
 Idle ─────────────────────────────────────────────────────────────────┘
 ```
 
-Stack mutation happens *before* OnMidpoint, not after. This means actions in OnMidpoint can reach the just-constructed target layer if they want (to inject pending state into it, for instance). For the common case — `session.NewMatch()` touching a long-lived `Match` object — the ordering doesn't matter, but the "mutation first" choice is the more useful default for cases where it does.
+Stack mutation happens *before* OnMidpoint, not after. This means actions in
+OnMidpoint can reach the just-constructed target layer if they want (to inject
+pending state into it, for instance). For the common case — `session.NewMatch()`
+touching a long-lived `Match` object — the ordering doesn't matter, but the "mutation
+first" choice is the more useful default for cases where it does.
 
-For `Push` transitions, `OutAnimating` is skipped. For `Pop`, `InAnimating` is skipped. OnStart, OnMidpoint, and OnComplete still fire in both cases; OnMidpoint is the natural place to release per-overlay resources during a pop.
+For `Push` transitions, `OutAnimating` is skipped. For `Pop`, `InAnimating` is
+skipped. OnStart, OnMidpoint, and OnComplete still fire in both cases; OnMidpoint is
+the natural place to release per-overlay resources during a pop.
 
 ### Re-entry policy
 
 If a `Trigger()` arrives while the machine is non-Idle, the policy field decides:
 
 - **Reject**: log and drop. Current scorched_moth behaviour.
-- **Queue** (depth 1): hold the request, apply it when the current transition reaches Idle. Default.
+- **Queue** (depth 1): hold the request, apply it when the current transition reaches
+  Idle. Default.
 - **Coalesce**: last-wins; replace any queued request with the new one.
 
-Queue depth >1 isn't supported in v1; if a designer needs that, they almost certainly want a different feature (a stack of forward navigations with "go back" semantics, e.g.).
+Queue depth >1 isn't supported in v1; if a designer needs that, they almost certainly
+want a different feature (a stack of forward navigations with "go back" semantics,
+e.g.).
 
 ## Side effects (the action registry)
 
-Side effects are application code triggered from points in the state machine. They are referenced from JSON by name and registered in C++ by the application.
+Side effects are application code triggered from points in the state machine. They
+are referenced from JSON by name and registered in C++ by the application.
 
 ```cpp
 using Action = std::function<void(std::function<void()> done)>;
@@ -347,9 +465,13 @@ flow.RegisterAction("assets.PreloadGame",
     });
 ```
 
-Actions are always treated as async by the runtime; sync actions just call `done()` immediately. This keeps one code path and lets long-running side effects (asset loading, network calls) slot in naturally without special handling.
+Actions are always treated as async by the runtime; sync actions just call `done()`
+immediately. This keeps one code path and lets long-running side effects (asset
+loading, network calls) slot in naturally without special handling.
 
-When multiple actions are listed on the same hook, they run **sequentially in JSON order**. Designer-authored ordering is preserved, and any one action can take its time without others jumping ahead.
+When multiple actions are listed on the same hook, they run **sequentially in JSON
+order**. Designer-authored ordering is preserved, and any one action can take its
+time without others jumping ahead.
 
 ### Where side effects live in the lifecycle
 
@@ -359,105 +481,193 @@ When multiple actions are listed on the same hook, they run **sequentially in JS
 | onMidpoint  | After stack mutation, before target's TransitionIn      | Reset model state visible during target's fade-in  |
 | onComplete  | After target's TransitionIn ends                        | Resume music; start post-entry timers              |
 
-The midpoint slot is the design payoff: state changes that need to be invisible to the player happen while neither the old nor the new view is animating. The match-reset example — `session.NewMatch()` between Title → Game — lets the new match be visible the moment GameLayer's fade-in starts, with no flash of the old state.
+The midpoint slot is the design payoff: state changes that need to be invisible to
+the player happen while neither the old nor the new view is animating. The
+match-reset example — `session.NewMatch()` between Title → Game — lets the new match
+be visible the moment GameLayer's fade-in starts, with no flash of the old state.
 
 ### Parameters — punted
 
-Actions are parameterless in v1. `session.NewMatch` reads its seed from app-side state (a "pending session config" or similar set up before triggering). Adding parameter passing through the JSON would require either:
+Actions are parameterless in v1. `session.NewMatch` reads its seed from app-side
+state (a "pending session config" or similar set up before triggering). Adding
+parameter passing through the JSON would require either:
 
 1. Per-action parameter schemas (so the editor can render UI for them).
 2. Opaque JSON blobs (no editor support).
 3. Stringly-typed action factories (`"session.NewMatch[seed=random]"`).
 
-None of these is right for v1. The editor isn't here yet, and app-side state is sufficient. Revisit once the editor lands: option 1 with per-action schemas is the right long-term answer but is a meaningful authoring-UI investment.
+None of these is right for v1. The editor isn't here yet, and app-side state is
+sufficient. Revisit once the editor lands: option 1 with per-action schemas is the
+right long-term answer but is a meaningful authoring-UI investment.
 
 ### Error handling and timeouts
 
-If an action's `done()` is never called, the transition stalls. The framework enforces a per-action timeout (configured in `GraphPolicy.actionTimeoutMs`) and force-advances on expiry with a loud log. The same policy applies to layers' `TransitionIn`/`Out` callbacks. Missing callbacks are almost always bugs and the runtime must not silently swallow them.
+If an action's `done()` is never called, the transition stalls. The framework
+enforces a per-action timeout (configured in `GraphPolicy.actionTimeoutMs`) and
+force-advances on expiry with a loud log. The same policy applies to layers'
+`TransitionIn`/`Out` callbacks. Missing callbacks are almost always bugs and the
+runtime must not silently swallow them.
 
-If an action throws, the framework logs and force-advances. Transitions in flight do not get rolled back; the system is forward-only.
+If an action throws, the framework logs and force-advances. Transitions in flight do
+not get rolled back; the system is forward-only.
 
 ### Cancellation — deliberately not supported
 
-Once a transition starts, it commits. "Conditional navigation" (e.g., confirm-before-quit) is the app's responsibility: the title's quit button shows a confirmation overlay, and only that overlay's OK button calls `Trigger("title.quit")`. Adding conditional cancellation to the graph would turn the runtime into a workflow engine, which is a different and much bigger product.
+Once a transition starts, it commits. "Conditional navigation" (e.g.,
+confirm-before-quit) is the app's responsibility: the title's quit button shows a
+confirmation overlay, and only that overlay's OK button calls
+`Trigger("title.quit")`. Adding conditional cancellation to the graph would turn the
+runtime into a workflow engine, which is a different and much bigger product.
 
-Similarly, actions don't return values back into the graph. If the C++ side needs to decide between transitions based on some outcome, it decides in code and triggers a different transition.
+Similarly, actions don't return values back into the graph. If the C++ side needs to
+decide between transitions based on some outcome, it decides in code and triggers a
+different transition.
 
 ## Modality
 
-Overlays carry a `modality` field that controls how the layers below them behave while the overlay is up:
+Overlays carry a `modality` field that controls how the layers below them behave
+while the overlay is up:
 
-- `Modal`: `moth_ui::LayerStack` short-circuits event delivery and `Update` calls to layers beneath this one. The pause menu doesn't need a manual `m_paused` flag in `GameLayer` — being covered by a modal overlay is what pauses the game.
-- `Passthrough`: layers beneath continue to update and receive non-handled input. Useful for HUD overlays, debug panels.
+- `Modal`: `moth_ui::LayerStack` short-circuits event delivery and `Update` calls to
+  layers beneath this one. The pause menu doesn't need a manual `m_paused` flag in
+  `GameLayer` — being covered by a modal overlay is what pauses the game.
+- `Passthrough`: layers beneath continue to update and receive non-handled input.
+  Useful for HUD overlays, debug panels.
 
-The `m_actionTriggered` double-click guard recurring in scorched_moth's overlay subclasses is subsumed by the framework's "transition already in progress" guard: once a button click triggers a transition, the runtime is non-Idle, and further clicks are rejected (or queued, per policy).
+The `m_actionTriggered` double-click guard recurring in scorched_moth's overlay
+subclasses is subsumed by the framework's "transition already in progress" guard:
+once a button click triggers a transition, the runtime is non-Idle, and further
+clicks are rejected (or queued, per policy).
 
-Implementation note: modal-skip is a `moth_ui::LayerStack` semantic extension, not purely a flow-system addition. The flag the flow system reads (`LayerSpec.modality`) maps to a property the LayerStack honours during its update/event-dispatch loop. The LayerStack change is the foundational dependency that lands before the flow system itself.
+Implementation note: modal-skip is a `moth_ui::LayerStack` semantic extension, not
+purely a flow-system addition. The flag the flow system reads (`LayerSpec.modality`)
+maps to a property the LayerStack honours during its update/event-dispatch loop. The
+LayerStack change is the foundational dependency that lands before the flow system
+itself.
 
 ## Consequences for application code
 
 The scorched_moth example, projected against the new system:
 
-- `Flow` class in `src/flow/` disappears in favour of `moth_ui::flow::Flow` constructed from a JSON-loaded `FlowGraph`.
+- `Flow` class in `src/flow/` disappears in favour of `moth_ui::flow::Flow`
+  constructed from a JSON-loaded `FlowGraph`.
 - `enum class Screen` disappears; layers are identified by string id in the graph.
 - `IFlowLayer` disappears (subsumed by `ITransitionParticipant`).
 - `UILayer` disappears (subsumed by `TransitioningLayer`).
-- `UIButton` moves to moth_ui as an opt-in widget; scorched_moth includes the moth_ui header instead of carrying its own copy.
-- `TitleLayer`, `PauseMenuLayer`, `GameOverLayer` disappear as C++ classes; they become layer entries in the graph JSON.
-- `GameLayer` remains as a C++ subclass because it owns and renders the game world. It becomes a view-only object: `Match` is owned externally (by an `Application`-level `Session` object or similar), and `GameLayer` reads from it. Replays don't reconstruct `GameLayer` — they call `Session::NewMatch()` from an `onMidpoint` action on the relevant transition and let the existing `GameLayer` re-enter via `OnEnter`.
-- `m_actionTriggered` guards, manual `PushOverlay`/`PopOverlay` calls, lambda chains threaded through constructors, and the per-layer `m_paused` flag all disappear.
+- `UIButton` moves to moth_ui as an opt-in widget; scorched_moth includes the moth_ui
+  header instead of carrying its own copy.
+- `TitleLayer`, `PauseMenuLayer`, `GameOverLayer` disappear as C++ classes; they
+  become layer entries in the graph JSON.
+- `GameLayer` remains as a C++ subclass because it owns and renders the game world.
+  It becomes a view-only object: `Match` is owned externally (by an
+  `Application`-level `Session` object or similar), and `GameLayer` reads from it.
+  Replays don't reconstruct `GameLayer` — they call `Session::NewMatch()` from an
+  `onMidpoint` action on the relevant transition and let the existing `GameLayer`
+  re-enter via `OnEnter`.
+- `m_actionTriggered` guards, manual `PushOverlay`/`PopOverlay` calls, lambda chains
+  threaded through constructors, and the per-layer `m_paused` flag all disappear.
 
-The remaining C++ surface for the app is: register factories, register actions, load the graph, pump `Tick`. Everything else is data.
+The remaining C++ surface for the app is: register factories, register actions, load
+the graph, pump `Tick`. Everything else is data.
 
 ## Public API additions to moth_ui
 
-This design introduces several new public headers in moth_ui. They're all opt-in — including none of them leaves existing moth_ui users unaffected.
+This design introduces several new public headers in moth_ui. They're all opt-in —
+including none of them leaves existing moth_ui users unaffected.
 
 - `moth_ui/flow/flow.h` — the `Flow` runtime.
-- `moth_ui/flow/flow_graph.h` — `FlowGraph`, `LayerSpec`, `TransitionSpec`, `TriggerSpec` and JSON loaders.
+- `moth_ui/flow/flow_graph.h` — `FlowGraph`, `LayerSpec`, `TransitionSpec`,
+  `TriggerSpec` and JSON loaders.
 - `moth_ui/flow/transition_participant.h` — the `ITransitionParticipant` interface.
 - `moth_ui/flow/transitioning_layer.h` — the `.mothui`-backed layer base.
 - `moth_ui/flow/code_driven_layer.h` — the code-driven layer base.
-- `moth_ui/flow/iclickable.h` — the `IClickable` interface. Lives under `flow/` because the flow runtime is its only current consumer; non-flow consumers can include it directly if they grow a need for it.
-- `moth_ui/widgets/ui_button.h` — the bundled `UIButton` widget that implements `IClickable`. (Lives under `widgets/` alongside `widget.h`, the CRTP base.)
+- `moth_ui/flow/iclickable.h` — the `IClickable` interface. Lives under `flow/`
+  because the flow runtime is its only current consumer; non-flow consumers can
+  include it directly if they grow a need for it.
+- `moth_ui/widgets/ui_button.h` — the bundled `UIButton` widget that implements
+  `IClickable`. (Lives under `widgets/` alongside `widget.h`, the CRTP base.)
 
-The `moth_ui/flow/` subdirectory is a coherent unit; users can ignore it wholesale or pull in the pieces they want.
+The `moth_ui/flow/` subdirectory is a coherent unit; users can ignore it wholesale or
+pull in the pieces they want.
 
 ## Editor implications (forward-looking)
 
 - Each LayerSpec is a card in a node diagram.
 - Each TransitionSpec is an arrow between two cards.
-- Each arrow exposes: a target dropdown (other layers); a kind dropdown; an out-clip dropdown (clips on source's layout); an in-clip dropdown (clips on target's layout); a trigger configurator; three lists (onStart/onMidpoint/onComplete) of action names from a dropdown populated by the app's registered actions.
-- The action registry is the contract surface between code and editor. Adding new options means adding actions in C++ and rebuilding; the editor's UI is data-driven from the registry.
-- Button-trigger dropdowns enumerate layout node ids whose factory-registered type implements `IClickable`. The editor learns about clickable widget types via the same `NodeFactory` registration `Widget<T>` uses today.
-- For layout-backed layers the editor can instantiate the actual `TransitioningLayer` and play transitions live in-tool. Code-driven layers can't preview at design time; the editor should show a stubbed placeholder and be honest about the limitation.
+- Each arrow exposes: a target dropdown (other layers); a kind dropdown; an out-clip
+  dropdown (clips on source's layout); an in-clip dropdown (clips on target's
+  layout); a trigger configurator; three lists (onStart/onMidpoint/onComplete) of
+  action names from a dropdown populated by the app's registered actions.
+- The action registry is the contract surface between code and editor. Adding new
+  options means adding actions in C++ and rebuilding; the editor's UI is data-driven
+  from the registry.
+- Button-trigger dropdowns enumerate layout node ids whose factory-registered type
+  implements `IClickable`. The editor learns about clickable widget types via the
+  same `NodeFactory` registration `Widget<T>` uses today.
+- For layout-backed layers the editor can instantiate the actual `TransitioningLayer`
+  and play transitions live in-tool. Code-driven layers can't preview at design time;
+  the editor should show a stubbed placeholder and be honest about the limitation.
 
-To keep that editor possible, the runtime needs to be embeddable in the editor process. The flow system's moth_ui-only dependency footprint already supports this: the editor pulls in moth_ui (it does today) and gets the flow runtime for free, with no moth_graphics window/graphics dragged in. Two further things to watch for during implementation: avoid `main()`-level singletons (the current scorched_moth code already avoids this), and don't bake global logger configuration into the Flow itself.
+To keep that editor possible, the runtime needs to be embeddable in the editor
+process. The flow system's moth_ui-only dependency footprint already supports this:
+the editor pulls in moth_ui (it does today) and gets the flow runtime for free, with
+no moth_graphics window/graphics dragged in. Two further things to watch for during
+implementation: avoid `main()`-level singletons (the current scorched_moth code
+already avoids this), and don't bake global logger configuration into the Flow
+itself.
 
 ## Validation surface (at graph-load time)
 
-A graph integrity check runs once at load and reports all problems before the first frame:
+A graph integrity check (`ValidateFlowGraph`) runs once and reports all
+failures at once rather than stopping on the first. The JSON loader calls it
+automatically; a **hand-built graph must call it explicitly** (scorched_moth
+does, in `PostCreateWindow`).
 
-- Every `to` field references a defined layer (or `"<back>"`).
-- Every `outClip` references a clip on the parent layer's layout (skipped for code-driven layers).
-- Every `inClip` references a clip on the target layer's layout (skipped for code-driven layers).
-- Every `trigger.button.id` references a node id present on the parent layer's layout whose registered type implements `IClickable`.
-- Every `factory` references a registered factory.
-- Every `ActionRef` references a registered action.
+**Implemented today** — purely structural checks that need no registries or
+layouts:
+
+- Layer ids are unique.
 - The `initial` layer exists.
-- No `Push` transition targets a `Screen`-kind layer (overlays can only push overlays).
-- No `Pop` transition has a non-`"<back>"` target.
+- Every `to` field references a defined layer (or `"<back>"`).
+- No `Pop` transition has a non-`"<back>"` target, and no non-`Pop`
+  transition targets `"<back>"`.
+- No `Push` transition targets a `Screen`-kind layer (overlays can only push
+  overlays).
 
-The validator should report **all** failures at once, not stop on the first — load-time bugs in big graphs are otherwise tedious to fix.
+**Designed but NOT yet implemented** — the checks below were intended but
+the current validator does not perform them. These references resolve
+*lazily* and fail (or no-op) at trigger time, not at load:
+
+- `outClip` / `inClip` reference a real clip on the relevant layout.
+- `trigger.button.id` references a node present on the layout whose type
+  implements `IClickable`.
+- `factory` references a registered factory.
+- Every `ActionRef` references a registered action.
+
+Until those land, treat clip names, button ids, factory names, and action
+names as unchecked strings: keep them under test coverage or grep them
+against your layouts and registrations when wiring transitions.
 
 ## Open questions deferred
 
-- **Wildcard transitions (`from: "*"`).** Designers will eventually want "Esc from any screen → settings overlay." Authoring sugar in the editor can expand to per-layer entries on save in v1; revisit a true wildcard in the runtime if the duplication becomes painful.
-- **Multi-trigger transitions.** `triggers: T[]` instead of `trigger: T`. Mechanically easy; defer until the editor exists and the authoring pain is observable.
-- **Action parameters.** Per-action schemas plus editor UI; revisit alongside the editor.
-- **Cached layer construction lifecycle.** When a `construction: Cached` layer is evicted (memory pressure, debug action), what happens? v1 keeps cached layers forever; revisit if memory matters.
-- **Auto-trigger pause semantics.** A layer with an `auto` trigger has its timer ticking while it's the topmost. What happens when a modal overlay covers it? Default: pause the timer (consistent with "modal blocks updates below"). Document but verify in implementation.
-- **History / back-stack.** No first-class history beyond the overlay stack. If apps need a "go back" stack across screen replaces, that's a future feature, not v1.
+- **Wildcard transitions (`from: "*"`).** Designers will eventually want "Esc from
+  any screen → settings overlay." Authoring sugar in the editor can expand to
+  per-layer entries on save in v1; revisit a true wildcard in the runtime if the
+  duplication becomes painful.
+- **Multi-trigger transitions.** `triggers: T[]` instead of `trigger: T`.
+  Mechanically easy; defer until the editor exists and the authoring pain is
+  observable.
+- **Action parameters.** Per-action schemas plus editor UI; revisit alongside the
+  editor.
+- **Cached layer construction lifecycle.** When a `construction: Cached` layer is
+  evicted (memory pressure, debug action), what happens? v1 keeps cached layers
+  forever; revisit if memory matters.
+- **Auto-trigger pause semantics.** A layer with an `auto` trigger has its timer
+  ticking while it's the topmost. What happens when a modal overlay covers it?
+  Default: pause the timer (consistent with "modal blocks updates below"). Document
+  but verify in implementation.
+- **History / back-stack.** No first-class history beyond the overlay stack. If apps
+  need a "go back" stack across screen replaces, that's a future feature, not v1.
 
 ## Out of scope for the first cut
 

--- a/docs/flow_system_design.md
+++ b/docs/flow_system_design.md
@@ -1,6 +1,6 @@
 # Flow System — Design
 
-Status: design exploration, not yet implemented.
+Status: implemented (PR #147). The runtime, layer bases, JSON loader, and bundled `UIButton` widget have all landed under `moth_ui/flow/` and `moth_ui/widgets/`. This document is the design-of-record; concrete naming or behaviour drifts should be reconciled against the headers.
 
 Location: moth_ui, as an opt-in utility. Existing moth_ui users with their own layer/transition setup ignore the new headers and lose nothing; new users include `<moth_ui/flow/...>` and pick it up. The system has no moth_graphics dependency — the entire flow runtime, layer bases, and supporting widgets are pure moth_ui.
 
@@ -31,7 +31,7 @@ Scorched_moth also defines a `UIButton` widget (a moth_ui `Widget<T>` CRTP subcl
 
 The serialisable artifact. An app loads a graph at startup, hands it to a `Flow` runtime, and from that point on, the graph drives navigation.
 
-```
+```text
 FlowGraph {
     initial:   LayerId
     policy:    GraphPolicy
@@ -48,7 +48,7 @@ GraphPolicy {
 
 One node in the graph. Carries everything the runtime needs to construct and animate this layer, plus the outgoing transitions originating from it.
 
-```
+```text
 LayerSpec {
     id:               LayerId          # unique within graph, e.g. "title", "game", "pause"
     factory:          string | null    # name of an app-registered factory; null → default
@@ -75,7 +75,7 @@ The trade-off: cross-cutting transitions (e.g., "from any layer, Esc → setting
 
 One outgoing edge. Locally addressable as `"layerId.transitionId"`.
 
-```
+```text
 TransitionSpec {
     id:        string              # local to parent layer; readable as "title.play"
     to:        LayerId | "<back>"  # "<back>" pops the topmost overlay
@@ -97,7 +97,7 @@ The graph loader can validate `inClip` references at load time by reading the ta
 
 A discriminated union describing how a transition is initiated:
 
-```
+```text
 TriggerSpec =
   | { type: "button", id: string }       # named UIButton in the source layer's layout
   | { type: "key",    key: KeyId }       # key event while source is active
@@ -167,7 +167,7 @@ A layer with no meaningful transition is a degenerate case: it inherits the defa
 // installs ClickActions on the matching UIButtons automatically. No custom
 // logic in this subclass; in fact, no subclass is needed at all if the layer
 // is purely graph-driven — see "When to subclass".
-class PauseLayer : public moth_graphics::flow::TransitioningLayer {
+class PauseLayer : public moth_ui::flow::TransitioningLayer {
 public:
     using TransitioningLayer::TransitioningLayer;
 };
@@ -176,7 +176,7 @@ public:
 ### Code-driven layer example
 
 ```cpp
-class TitleSplashLayer : public moth_graphics::flow::CodeDrivenLayer {
+class TitleSplashLayer : public moth_ui::flow::CodeDrivenLayer {
 public:
     void TransitionIn(std::string_view tag, std::function<void()> done) override {
         if (tag == "fast_fade") {
@@ -297,7 +297,7 @@ The `Flow` has no knowledge of any specific layer or screen — those are addres
 
 Once a trigger fires, the runtime walks a fixed sequence of phases. Each phase can be synchronous (`done()` fires immediately) or asynchronous (the framework waits for an explicit callback).
 
-```
+```text
 Idle
   └─ Trigger(t) accepted
 OnStart        ─── run t.onStart actions sequentially ───────────────┐
@@ -418,8 +418,8 @@ This design introduces several new public headers in moth_ui. They're all opt-in
 - `moth_ui/flow/transition_participant.h` — the `ITransitionParticipant` interface.
 - `moth_ui/flow/transitioning_layer.h` — the `.mothui`-backed layer base.
 - `moth_ui/flow/code_driven_layer.h` — the code-driven layer base.
-- `moth_ui/iclickable.h` — the `IClickable` interface (top-level in moth_ui; not under flow/, since custom widgets that aren't graph-driven can also benefit).
-- `moth_ui/nodes/ui_button.h` — the bundled `UIButton` widget that implements `IClickable`.
+- `moth_ui/flow/iclickable.h` — the `IClickable` interface. Lives under `flow/` because the flow runtime is its only current consumer; non-flow consumers can include it directly if they grow a need for it.
+- `moth_ui/widgets/ui_button.h` — the bundled `UIButton` widget that implements `IClickable`. (Lives under `widgets/` alongside `widget.h`, the CRTP base.)
 
 The `moth_ui/flow/` subdirectory is a coherent unit; users can ignore it wholesale or pull in the pieces they want.
 

--- a/docs/flow_system_guide.md
+++ b/docs/flow_system_guide.md
@@ -1,0 +1,412 @@
+# Flow System — Consumer Guide
+
+How to use the moth_ui flow system to drive screen/overlay navigation in
+your application. This is the practical how-to; for the design rationale
+(why transitions nest under layers, why the stack mutates before the
+midpoint, deferred editor scope) see
+[`flow_system_design.md`](flow_system_design.md).
+
+The worked example throughout is **scorched_moth**, the framework's main
+consumer. Its graph is assembled in `src/scorched_application.cpp`
+(`BuildFlowGraph()` plus the factory/action registrations); its layers
+live in `scorched_moth/src/layers/`.
+
+## What it is
+
+A navigation runtime. You describe your app as a graph of **layers**
+(screens and overlays) and the **transitions** between them. The runtime
+plays the in/out animations, mutates the layer stack, and sequences your
+side effects, so layer code stays focused on its own job instead of
+push/pop plumbing and double-click guards.
+
+It's pure moth_ui — no moth_graphics dependency. Existing moth_ui apps
+that roll their own layer management can ignore the `moth_ui/flow/`
+headers entirely and lose nothing.
+
+## The two halves
+
+- **`FlowGraph`** — plain data: the layers, their transitions, triggers,
+  and side-effect hooks. Either hand-built in C++ or loaded from JSON.
+- **`Flow`** — the runtime. You hand it the graph plus references to your
+  `LayerStack` and `Context`, register the factories and actions the graph
+  names by string, and pump it each frame.
+
+Everything the graph references — layer factories, side-effect actions —
+is resolved by **name** against registries you populate in C++. The Flow
+itself knows nothing about any specific screen.
+
+## Wiring the runtime into your app
+
+Four steps at startup, then two calls per frame. From scorched_moth:
+
+```cpp
+// 1. Build (or load) the graph, then validate it. Hand-built graphs are
+//    NOT validated for you — call the validator yourself or structural
+//    errors only surface lazily at Trigger time.
+auto graph = BuildFlowGraph();
+auto errors = moth_ui::flow::ValidateFlowGraph(graph);
+for (auto const& e : errors) {
+    spdlog::error("flow graph error [{}.{}]: {}",
+                  e.layerId, e.transitionId, e.message);
+}
+// (bail if !errors.empty())
+
+// 2. Construct the runtime. Takes only moth_ui types — no Window.
+m_flow = std::make_unique<moth_ui::flow::Flow>(
+    m_window->GetLayerStack(), m_window->GetMothContext(), std::move(graph));
+
+// 3. Register custom layer factories (by name) for layers that need a
+//    C++ subclass. Closures capture whatever app state the layer needs.
+m_flow->RegisterFactory("game",
+    [this](moth_ui::Context& ctx, moth_ui::flow::LayerSpec const&) {
+        return std::make_unique<RoundLayer>(
+            ctx, *m_flow, *m_session, m_window->GetGraphics());
+    });
+
+// 4. Register side-effect actions (by name).
+m_flow->RegisterAction("session.StartMatch",
+    [this](std::function<void()> done) { m_session->StartMatch(); done(); });
+
+// Create + push the initial layer. Call once, after registrations.
+m_flow->Start();
+```
+
+Per frame:
+
+```cpp
+bool OnEvent(moth_ui::Event const& event) override {
+    // Feed the Flow BEFORE the LayerStack so key triggers get first look.
+    if (m_flow && m_flow->OnEvent(event)) {
+        return true;   // consumed by a key trigger
+    }
+    return Application::OnEvent(event);
+}
+
+void TickFixed(uint32_t ticks) override {
+    if (m_flow) {
+        m_flow->Tick(ticks);   // advances the transition state machine
+    }
+}
+```
+
+That's the entire required surface: **construct, register, `Start`, then
+`OnEvent` + `Tick`**.
+
+> **Self-registered widgets.** If your buttons (or other widgets) register
+> themselves with the `NodeFactory` and are referenced only by layout-class
+> string, the linker may strip them. Call `moth_ui::EnsureWidgetsRegistered()`
+> once at startup (scorched_moth does this in `PostCreateWindow`) so the
+> bundled widgets survive.
+
+## Building the graph
+
+### Hand-built (what scorched_moth does)
+
+The graph is just structs. scorched_moth assembles it in code rather than
+loading JSON — equivalent to what a designer-authored `flow.json` would
+describe, but driven without the loader:
+
+```cpp
+moth_ui::flow::FlowGraph graph;
+graph.initial = "title";
+graph.policy.onReentry = moth_ui::flow::ReentryPolicy::Queue;
+
+moth_ui::flow::LayerSpec title;
+title.id = "title";
+title.layout = "assets/layouts/screen_title.mothui";
+title.kind = moth_ui::flow::LayerKind::Screen;
+
+moth_ui::flow::TransitionSpec play;
+play.id = "play";
+play.to = "match_setup";
+play.kind = moth_ui::flow::TransitionKind::Replace;
+play.inClip = "transition_in";
+play.trigger.kind = moth_ui::flow::TriggerKind::Button;
+play.trigger.id = "btn_start";
+title.transitions.push_back(std::move(play));
+
+graph.layers.push_back(std::move(title));
+```
+
+### JSON-loaded
+
+`LoadFlowGraphFromFile(path)` / `LoadFlowGraphFromJson(json)` return a
+`LoadResult { std::optional<FlowGraph> graph; std::vector<…> errors; }`
+with `ok()` true when parse + structural validation both pass. The JSON
+loader runs `ValidateFlowGraph` for you; the hand-built path does not.
+
+The same structs map straight to JSON. Enum fields are strings, matched
+case-insensitively, and every field with a default may be omitted. This
+graph — a title screen, a game screen, and a modal pause overlay — is
+equivalent to the hand-built form above:
+
+```json
+{
+  "initial": "title",
+  "policy": { "onReentry": "queue", "actionTimeoutMs": 5000 },
+  "layers": [
+    {
+      "id": "title",
+      "layout": "assets/layouts/screen_title.mothui",
+      "kind": "screen",
+      "transitions": [
+        {
+          "id": "play",
+          "to": "game",
+          "kind": "replace",
+          "inClip": "transition_in",
+          "trigger": { "type": "button", "id": "btn_start" },
+          "onMidpoint": ["session.StartMatch"]
+        },
+        {
+          "id": "quit",
+          "to": "title",
+          "kind": "replace",
+          "trigger": { "type": "button", "id": "btn_quit" },
+          "onStart": ["app.Quit"]
+        }
+      ]
+    },
+    {
+      "id": "game",
+      "factory": "game",
+      "layout": "assets/layouts/game_hud.mothui",
+      "kind": "screen",
+      "transitions": [
+        {
+          "id": "pause",
+          "to": "pause",
+          "kind": "push",
+          "trigger": { "type": "key", "key": "Escape" }
+        }
+      ]
+    },
+    {
+      "id": "pause",
+      "layout": "assets/layouts/screen_pause_menu.mothui",
+      "kind": "overlay",
+      "modality": "modal",
+      "transitions": [
+        {
+          "id": "resume",
+          "to": "<back>",
+          "kind": "pop",
+          "trigger": { "type": "button", "id": "btn_resume" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Field notes: `kind` defaults to `"replace"` (transitions) / `"screen"`
+(layers); a `Key` trigger names the key by its `moth_ui::Key` enum name
+(e.g. `"Escape"`); an `Event` trigger takes `"id"` (or `"name"`); an
+`Auto` trigger takes `"afterMs"`. JSON moves only the graph *structure*
+into data — the `factory` (`"game"`) and the action names
+(`"session.StartMatch"`, `"app.Quit"`) still have to be registered in C++
+exactly as with a hand-built graph.
+
+### LayerSpec fields
+
+| Field             | Meaning                                                      |
+|-------------------|-------------------------------------------------------------|
+| `id`              | Unique layer id, e.g. `"title"`, `"game"`, `"pause"`.       |
+| `factory`         | `std::optional` name of a registered factory; empty → default (a `TransitioningLayer` from `layout`). |
+| `layout`          | Path to a `.mothui`, consumed by the default factory.       |
+| `kind`            | `LayerKind::Screen` or `Overlay`.                           |
+| `modality`        | `Modality::Modal` (default) or `Passthrough` — overlays only. |
+| `construction`    | `Construction::Fresh` (default, rebuilt each entry) or `Cached` (instance preserved across visits). |
+| `defaultInClip`   | Fallback in-clip name (default `"transition_in"`).          |
+| `defaultOutClip`  | Fallback out-clip name (default `"transition_out"`).        |
+| `transitions`     | Outgoing edges from this layer.                             |
+
+### TransitionSpec fields
+
+| Field        | Meaning                                                           |
+|--------------|------------------------------------------------------------------|
+| `id`         | Local to the parent layer; addressed globally as `"layerId.transitionId"`. |
+| `to`         | Target layer id, or `"<back>"` (Pop only — pops the topmost overlay). |
+| `kind`       | `Replace`, `Push`, or `Pop`.                                     |
+| `inClip`     | `std::optional` clip on the **target**'s layout; empty → target's `defaultInClip`. |
+| `outClip`    | `std::optional` clip on the **source**'s layout; empty → source's `defaultOutClip`. |
+| `trigger`    | How the transition fires (below).                                |
+| `onStart` / `onMidpoint` / `onComplete` | Lists of registered action names, run at fixed points (below). |
+
+## Triggers
+
+A `TriggerSpec` has a `kind` and (for Button/Event) an `id`:
+
+- **`Button`** — `id` is the layout node id of an `IClickable` widget on the
+  source layer. The runtime auto-binds the click for you (see below).
+- **`Key`** — `trigger.key` is a `moth_ui::Key`; fires on key-down while the
+  source layer is the topmost active layer. This is why `Flow::OnEvent`
+  must see events before the LayerStack.
+- **`Event`** — `id` is a name your layer code passes to
+  `m_flow.Emit("name")`. The escape hatch for things only C++ knows (a
+  match ending, an async callback returning). scorched_moth's `RoundLayer`
+  emits `"match_ended"` when the round ends.
+- **`Auto`** — `trigger.afterMs` fires the transition N ms after the layer
+  becomes active (splash → title style).
+
+A transition with **no trigger set** is never fired by user input — you
+fire it yourself with `m_flow.Trigger("layerId.transitionId")`. scorched_moth
+uses these for programmatic hops like `game.open_shop` and the
+disconnect-notice transitions.
+
+## Layers
+
+### The default: `TransitioningLayer`
+
+A layer whose spec has no `factory` is built as a `TransitioningLayer` from
+its `layout`. It loads the `.mothui`, dispatches events into it, and
+interprets each transition `tag` as a **clip name**: if the clip exists it
+plays it and waits for `EventAnimationStopped` before calling `done()`;
+otherwise `done()` fires immediately. A purely graph-driven screen (title,
+pause menu) needs **no C++ subclass at all**.
+
+Button auto-binding: when a layer mounts, the Flow walks its transitions
+and, for each `Button` trigger, does
+`dynamic_cast<IClickable*>(root->FindChild(id).get())->SetClickAction(...)`.
+The widget can be the bundled `moth_ui::UIButton` or any app widget that
+implements `IClickable` — the runtime only knows the interface.
+
+### When to subclass
+
+Subclass `TransitioningLayer` when a layer holds state or behaviour the
+graph can't express:
+
+- it reads/owns a long-lived app object (scorched_moth's `RoundLayer`
+  reads the `Session`/`Round`);
+- it emits programmatic events back into the flow (`m_flow.Emit(...)`);
+- it intercepts a flow-wired button to add gating logic (see the gotcha
+  below).
+
+Register the subclass with `RegisterFactory(name, …)` and set the spec's
+`factory` to that name.
+
+### `CodeDrivenLayer`
+
+For layers with no `.mothui` at all — you override `TransitionIn`/`Out`,
+drive your own animation, and call `done()` when finished. The `tag` is
+yours to interpret however you like. Use this for ad-hoc drawn screens.
+
+## Transition kinds, the phase machine, and side effects
+
+Replace, Push, and Pop share one pipeline and differ only in the
+stack-mutation step:
+
+| kind    | OutAnimating         | Stack mutation             | InAnimating         |
+|---------|----------------------|----------------------------|---------------------|
+| Replace | source.TransitionOut | remove source, push target | target.TransitionIn |
+| Push    | *(skipped)*          | push target                | target.TransitionIn |
+| Pop     | source.TransitionOut | remove source              | *(skipped)*         |
+
+Every trigger walks this sequence; each phase may be sync or async (the
+runtime waits for `done()` before advancing):
+
+```
+Idle → onStart → OutAnimating → [stack mutation] → onMidpoint
+     → InAnimating → onComplete → Idle
+```
+
+Side-effect hooks (lists of action names, run **sequentially in order**):
+
+| Hook         | Fires                                              | Typical use                          |
+|--------------|----------------------------------------------------|--------------------------------------|
+| `onStart`    | before the source's out-animation                  | fade music out; freeze a sim         |
+| `onMidpoint` | after stack mutation, before the target's in-anim  | inject state into the just-built target; reset model invisibly |
+| `onComplete` | after the target's in-animation                    | resume music; start post-entry timers |
+
+The stack mutates **before** `onMidpoint`, so midpoint actions can reach
+the freshly-constructed target. scorched_moth uses `onMidpoint` for
+`session.StartMatch` / `session.NextRound` so the new round is live the
+instant the game layer fades in.
+
+Actions are `std::function<void(std::function<void()> done)>` and are
+always treated as async — synchronous work just calls `done()` immediately.
+A long-running action (asset load, network round-trip) slots in with no
+special handling, but **must call `done()` exactly once** or the transition
+stalls (the watchdog below will eventually force it).
+
+## Overlays, modality, and `<back>`
+
+- **Screen** layers replace the base; only one is the base at a time.
+- **Overlay** layers (`Push`) stack on top. `Pop` with `to = "<back>"`
+  removes the topmost overlay.
+- **Modality** controls layers *below* an overlay: `Modal` (default) stops
+  the LayerStack from delivering events/updates beneath it — being covered
+  by a modal pause menu is what pauses the game, no `m_paused` flag needed.
+  `Passthrough` lets lower layers keep updating (HUDs, debug panels).
+
+A `Replace` from inside an overlay back to a base screen pops intervening
+overlays for you. But the runtime is deliberately minimal: for **multi-step
+hops** (pop an overlay, then replace the screen underneath) compose them in
+your own code with a `Pop` whose `onComplete` action calls
+`m_flow.Trigger(...)` for the next leg — don't expect a single transition to
+do both. scorched_moth's results-overlay quit does exactly this
+(`round_results.quit` → `app.QuitToTitle` → `game.quit`).
+
+## Re-entry policy and the timeout watchdog
+
+If a `Trigger`/`Emit` arrives mid-transition, `GraphPolicy.onReentry`
+decides: **Reject** (drop + log), **Queue** (hold one, apply at Idle —
+scorched_moth's choice), or **Coalesce** (last-wins). This subsumes the
+old per-overlay double-click guards: once a click starts a transition the
+runtime is non-Idle and further clicks are dropped or queued.
+
+A per-phase watchdog guards async work: if an animation or action doesn't
+call `done()` within `GraphPolicy.actionTimeoutMs` (default 5000 ms) the
+runtime logs a warning and force-advances. Missing callbacks are bugs; the
+runtime won't silently hang on them.
+
+## Validation — and what it does *not* catch
+
+`ValidateFlowGraph(graph)` returns a list of `GraphValidationError`. The
+JSON loader runs it automatically; **a hand-built graph does not — call it
+yourself.** It currently checks:
+
+- layer-id uniqueness;
+- `initial` references a real layer;
+- every transition `to` references a defined layer (or `"<back>"`);
+- `Pop` transitions target `"<back>"`, and non-`Pop` transitions don't;
+- `Push` targets an `Overlay`, not a `Screen`.
+
+It does **not** (yet) verify clip names, button-node ids, factory names, or
+action names. Those resolve lazily: a typo'd `inClip`, a `trigger.id` that
+doesn't match any node, an unregistered `factory` or action name fails (or
+no-ops) at trigger time, not at load. Keep those strings under test
+coverage, or grep them against your layouts/registrations when wiring new
+transitions.
+
+## Gotchas
+
+- **Button bindings install before `OnEnter`.** The Flow wires flow-graph
+  button clicks when the layer mounts, *before* your `OnEnter` runs. A
+  layer constructor therefore can't intercept a flow-wired button — if you
+  need to override a button's action (e.g. to gate on networked readiness),
+  re-set it from `OnEnter`, not the ctor. scorched_moth's `MatchSetupLayer`
+  and `RoundResultsLayer` do this for `btn_prepare` / `btn_gonext`.
+- **`inClip` lives on the target, `outClip` on the source.** A transition
+  names an in-clip defined on the layer it's heading *to*.
+- **No history/back-stack across screens.** `"<back>"` only pops the
+  overlay stack; there's no automatic "previous screen" memory.
+- **Cached layers live forever (v1).** A `Construction::Cached` layer's
+  instance is reused across visits and never evicted.
+- **Keep the runtime narrow.** Niche multi-layer transition choreography
+  belongs in app code (chained `Pop` + `onComplete` + `Trigger`), not in
+  new runtime features.
+
+## Header map
+
+All opt-in; including none leaves existing moth_ui users unaffected.
+
+| Header                                  | Provides                                  |
+|-----------------------------------------|-------------------------------------------|
+| `moth_ui/flow/flow.h`                   | the `Flow` runtime                        |
+| `moth_ui/flow/flow_graph.h`             | `FlowGraph`, `LayerSpec`, `TransitionSpec`, `TriggerSpec`, the enums, the validator, and JSON loaders |
+| `moth_ui/flow/transition_participant.h` | the `ITransitionParticipant` interface    |
+| `moth_ui/flow/transitioning_layer.h`    | the `.mothui`-backed layer base           |
+| `moth_ui/flow/code_driven_layer.h`      | the code-driven layer base                |
+| `moth_ui/flow/iclickable.h`             | the `IClickable` interface                |
+| `moth_ui/widgets/ui_button.h`           | the bundled `UIButton` widget             |

--- a/include/moth_ui/events/event_mouse.h
+++ b/include/moth_ui/events/event_mouse.h
@@ -138,11 +138,17 @@ namespace moth_ui {
     public:
         /**
          * @brief Constructs the event.
-         * @param delta Scroll amount, positive values scroll up/forward.
+         * @param delta    Scroll amount, positive values scroll up/forward.
+         * @param position Cursor position in screen space at the time of the
+         *                 scroll. Wheel events carry no position of their own,
+         *                 so the platform stamps the current cursor location;
+         *                 widgets need it to decide whether the scroll is over
+         *                 them without relying on a cached move position.
          */
-        EventMouseWheel(IntVec2 const& delta)
+        EventMouseWheel(IntVec2 const& delta, IntVec2 const& position)
             : Event(GetStaticType())
-            , m_delta(delta) {}
+            , m_delta(delta)
+            , m_position(position) {}
 
         /// @brief Returns the static type code for EventMouseWheel.
         static constexpr int GetStaticType() { return EVENTTYPE_MOUSE_WHEEL; }
@@ -150,8 +156,11 @@ namespace moth_ui {
         /// @brief Returns the scroll delta.
         IntVec2 const& GetDelta() const { return m_delta; }
 
+        /// @brief Returns the cursor position in screen space.
+        IntVec2 const& GetPosition() const { return m_position; }
+
         std::unique_ptr<Event> Clone() const override {
-            return std::make_unique<EventMouseWheel>(m_delta);
+            return std::make_unique<EventMouseWheel>(m_delta, m_position);
         }
 
         EventMouseWheel(EventMouseWheel const&) = default;
@@ -162,5 +171,6 @@ namespace moth_ui {
 
     private:
         IntVec2 m_delta;
+        IntVec2 m_position;
     };
 }

--- a/include/moth_ui/flow/code_driven_layer.h
+++ b/include/moth_ui/flow/code_driven_layer.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "moth_ui/flow/transition_participant.h"
+#include "moth_ui/layers/layer.h"
+
+namespace moth_ui::flow {
+
+    /**
+     * @brief Layer base for screens whose visuals and transitions are written by hand.
+     *
+     * Subclasses override @ref Draw and @ref Update as usual, and additionally
+     * override @ref TransitionIn / @ref TransitionOut to drive their own
+     * animation, calling the supplied @c done callback when finished. The
+     * @c tag string can be switched on to pick between transition variants.
+     *
+     * The default implementation of both transition hooks fires @c done
+     * immediately, which is the right behaviour for layers that don't need
+     * an explicit transition (debug overlays, instant cuts).
+     *
+     * Code-driven layers do not provide a layout, so button-trigger bindings
+     * from the flow graph are skipped automatically.
+     */
+    class CodeDrivenLayer : public Layer, public ITransitionParticipant {
+    public:
+        CodeDrivenLayer() = default;
+        CodeDrivenLayer(CodeDrivenLayer const&) = delete;
+        CodeDrivenLayer(CodeDrivenLayer&&) = delete;
+        CodeDrivenLayer& operator=(CodeDrivenLayer const&) = delete;
+        CodeDrivenLayer& operator=(CodeDrivenLayer&&) = delete;
+        ~CodeDrivenLayer() override = default;
+
+        /// @copydoc ITransitionParticipant::TransitionIn
+        void TransitionIn(std::string_view /*tag*/, std::function<void()> done) override {
+            done();
+        }
+
+        /// @copydoc ITransitionParticipant::TransitionOut
+        void TransitionOut(std::string_view /*tag*/, std::function<void()> done) override {
+            done();
+        }
+    };
+}

--- a/include/moth_ui/flow/flow.h
+++ b/include/moth_ui/flow/flow.h
@@ -1,0 +1,196 @@
+#pragma once
+
+#include "moth_ui/events/event_key.h"
+#include "moth_ui/events/event_listener.h"
+#include "moth_ui/flow/flow_graph.h"
+#include "moth_ui/moth_ui_fwd.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace moth_ui::flow {
+
+    class ITransitionParticipant;
+
+    /**
+     * @brief Runtime that drives navigation through a @ref FlowGraph.
+     *
+     * Construction sequence:
+     * 1. Build the @ref Flow with a @ref FlowGraph and references to the
+     *    app's @ref LayerStack and @ref Context.
+     * 2. Register any custom layer factories with @ref RegisterFactory and
+     *    side-effect actions with @ref RegisterAction.
+     * 3. Call @ref Start to create and push the @c initial layer.
+     * 4. Each frame, call @ref OnEvent on incoming events before delivering
+     *    them to the LayerStack, and @ref Tick after.
+     *
+     * Triggers (button clicks, key presses, programmatic emits) move the
+     * runtime through a fixed phase machine:
+     * @c onStart → @c OutAnimating → stack mutation → @c onMidpoint →
+     * @c InAnimating → @c onComplete. Push skips @c OutAnimating; Pop skips
+     * @c InAnimating.
+     *
+     * Stack mutations are deferred to @ref Tick so callers can fire triggers
+     * from inside event handlers without invalidating LayerStack iterators.
+     */
+    class Flow : public IEventListener {
+    public:
+        /**
+         * @brief Builds a layer instance for a given @ref LayerSpec.
+         *
+         * Returns @c nullptr if the spec cannot be honoured. The runtime
+         * logs and aborts the in-flight transition in that case.
+         */
+        using LayerFactory = std::function<std::unique_ptr<Layer>(Context&, LayerSpec const&)>;
+
+        /**
+         * @brief Application-side side effect, fired from one of the lifecycle hooks.
+         *
+         * The action must invoke @p done exactly once when finished. Synchronous
+         * work calls it immediately; asynchronous work calls it from a completion
+         * callback.
+         */
+        using Action = std::function<void(std::function<void()> done)>;
+
+        /**
+         * @brief Constructs the runtime against a layer stack, context, and parsed graph.
+         * @param stack   Layer stack the runtime owns transitions on.
+         * @param context Rendering context passed to the default layer factory.
+         * @param graph   Parsed, structurally-valid flow graph.
+         */
+        Flow(LayerStack& stack, Context& context, FlowGraph graph);
+        Flow(Flow const&) = delete;
+        Flow(Flow&&) = delete;
+        Flow& operator=(Flow const&) = delete;
+        Flow& operator=(Flow&&) = delete;
+        ~Flow() override;
+
+        /**
+         * @brief Registers a custom layer factory by name.
+         *
+         * A @ref LayerSpec whose @c factory field equals @p name will be
+         * built by @p factory rather than the default
+         * (TransitioningLayer-from-layout) factory.
+         */
+        void RegisterFactory(std::string name, LayerFactory factory);
+
+        /**
+         * @brief Registers a side-effect action by name.
+         *
+         * Referenced by the graph through @c onStart / @c onMidpoint /
+         * @c onComplete arrays on transitions.
+         */
+        void RegisterAction(std::string name, Action action);
+
+        /**
+         * @brief Creates and pushes the initial layer, then starts its TransitionIn.
+         *
+         * Must be called once before the first @ref Tick. Safe to call after
+         * all factories and actions have been registered.
+         */
+        void Start();
+
+        /**
+         * @brief Fires a specific transition identified as @c "layerId.transitionId".
+         *
+         * If the runtime is mid-transition, the request is dropped or queued
+         * according to @ref GraphPolicy::onReentry.
+         */
+        void Trigger(std::string_view qualifiedId);
+
+        /**
+         * @brief Routes a programmatic event to the topmost active layer's @c event triggers.
+         *
+         * Layer code can call this to bridge C++-side state changes (a match
+         * ending, an auth callback returning) into the flow graph.
+         */
+        void Emit(std::string_view eventName);
+
+        /**
+         * @brief Pre-stack event filter: dispatches @c key triggers for the active layer.
+         *
+         * Callers should invoke this on every event before forwarding to the
+         * LayerStack. Returns @c true if the event was consumed by a key
+         * trigger and should not propagate further.
+         */
+        bool OnEvent(Event const& event) override;
+
+        /**
+         * @brief Advances the transition state machine by @p ticks milliseconds.
+         * @param ticks Elapsed time since the previous call.
+         */
+        void Tick(uint32_t ticks);
+
+    private:
+        enum class Phase {
+            Idle,
+            OnStart,
+            OutAnimating,
+            DoStackMutation,
+            OnMidpoint,
+            InAnimating,
+            OnComplete,
+        };
+
+        struct ActiveTransition {
+            LayerSpec const* sourceSpec = nullptr;
+            TransitionSpec const* spec = nullptr;
+            LayerSpec const* targetSpec = nullptr;   ///< Null for Pop.
+            Layer* sourceLayer = nullptr;
+            ITransitionParticipant* sourceParticipant = nullptr;
+            Layer* targetLayer = nullptr;            ///< Populated during stack mutation.
+            ITransitionParticipant* targetParticipant = nullptr;
+            std::vector<ActionRef> actionQueue;
+            bool actionInFlight = false;
+            uint32_t phaseElapsedMs = 0;
+        };
+
+        struct StackEntry {
+            LayerSpec const* spec = nullptr;
+            Layer* layer = nullptr;
+            ITransitionParticipant* participant = nullptr;
+        };
+
+        std::unique_ptr<Layer> BuildLayer(LayerSpec const& spec);
+        void InstallButtonBindings(LayerSpec const& spec, ITransitionParticipant* participant);
+        void BeginTransition(LayerSpec const& source, TransitionSpec const& transition);
+        void AdvancePhase();
+        void EnterPhase(Phase next);
+        void RunNextAction();
+        void OnPhaseDone();
+        void DoStackMutation();
+        void FinishTransition();
+        bool DispatchKey(EventKey const& event);
+        StackEntry* TopmostActive();
+        LayerSpec const* ResolvePopTarget() const;
+        TransitionSpec const* FindTransition(std::string_view qualifiedId, LayerSpec const*& outLayer) const;
+
+        LayerStack& m_stack;
+        Context& m_context;
+        FlowGraph m_graph;
+
+        std::unordered_map<std::string, LayerFactory> m_factories;
+        std::unordered_map<std::string, Action> m_actions;
+
+        // Active screen + overlays on top. Screen always at index 0 when present.
+        std::vector<StackEntry> m_active;
+
+        // Cached layer instances (LayerSpec.construction == Cached).
+        std::unordered_map<std::string, std::unique_ptr<Layer>> m_cached;
+
+        Phase m_phase = Phase::Idle;
+        ActiveTransition m_activeTransition;
+        bool m_phaseDone = false;
+
+        // Pending re-entry trigger (Queue / Coalesce). Holds at most one.
+        std::optional<std::string> m_pendingTrigger;
+
+        bool m_started = false;
+    };
+}

--- a/include/moth_ui/flow/flow.h
+++ b/include/moth_ui/flow/flow.h
@@ -158,6 +158,7 @@ namespace moth_ui::flow {
         };
 
         std::unique_ptr<Layer> BuildLayer(LayerSpec const& spec);
+        void PushTargetLayer(LayerSpec const& spec);
         void InstallButtonBindings(LayerSpec const& spec, ITransitionParticipant* participant);
         void BeginTransition(LayerSpec const& source, TransitionSpec const& transition);
         void AdvancePhase();

--- a/include/moth_ui/flow/flow_graph.h
+++ b/include/moth_ui/flow/flow_graph.h
@@ -1,0 +1,177 @@
+#pragma once
+
+#include "moth_ui/events/event_key.h"
+
+#include <nlohmann/json.hpp>
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace moth_ui::flow {
+
+    /// @brief String identifier of a layer entry within a @ref FlowGraph.
+    using LayerId = std::string;
+
+    /// @brief Identifier of a transition local to its owning layer (e.g. @c "play").
+    using TransitionId = std::string;
+
+    /// @brief Name of an action registered with the @ref Flow runtime.
+    using ActionRef = std::string;
+
+    /// @brief Name of an animation clip on a layer's layout.
+    using ClipName = std::string;
+
+    /// @brief Sentinel target value for a @ref TransitionKind::Pop transition.
+    inline constexpr char const* kBackTarget = "<back>";
+
+    /// @brief Stack role of a layer entry.
+    enum class LayerKind {
+        Screen,  ///< Bottom-of-stack root view. Only one screen is ever active at a time; a Replace swaps it.
+        Overlay, ///< Pushed on top of a screen (or another overlay) without replacing it. Pop returns to whatever sits below.
+    };
+
+    /// @brief Whether an overlay blocks input and updates of layers beneath it.
+    enum class Modality {
+        Modal,        ///< LayerStack stops dispatching events and Update calls to layers below this one (e.g. pause menus).
+        Passthrough,  ///< Layers below continue to receive events and updates (e.g. HUDs, debug panels).
+    };
+
+    /// @brief Construction policy for a layer instance.
+    enum class Construction {
+        Fresh,  ///< Build a new instance every time the layer is entered. Old instance is destroyed on exit.
+        Cached, ///< Reuse the same instance across visits. Useful for layers that own expensive or stateful objects (e.g. game world).
+    };
+
+    /// @brief Stack-mutation flavour of a transition.
+    enum class TransitionKind {
+        Replace, ///< Remove the source (and any overlays above it), then push the target. Used for screen-to-screen navigation.
+        Push,    ///< Add the target on top of the current stack without removing anything. Used for showing an overlay.
+        Pop,     ///< Remove the topmost layer; target must be @c "<back>". Used for dismissing an overlay.
+    };
+
+    /// @brief Policy applied when a new trigger arrives mid-transition.
+    enum class ReentryPolicy {
+        Reject,   ///< Drop the new trigger with a log message.
+        Queue,    ///< Hold one pending trigger and fire it when the current transition reaches Idle.
+        Coalesce, ///< Hold one pending trigger; replace it with each new arrival (last-wins).
+    };
+
+    /// @brief Flavour of a transition trigger.
+    enum class TriggerKind {
+        Button, ///< Bound to an @ref IClickable node on the source layer's layout, looked up by id.
+        Key,    ///< Bound to a keyboard key. Fires on key-down while the source layer is the topmost active.
+        Event,  ///< Bound to a named event emitted programmatically via @ref Flow::Emit.
+        Auto,   ///< Fires automatically after a fixed delay once the source layer becomes active (e.g. splash → title).
+    };
+
+    /**
+     * @brief Discriminated union describing how a transition is initiated.
+     *
+     * The interpretation of @c id depends on @c kind:
+     * - @c Button: layout node id of an @ref IClickable widget.
+     * - @c Event:  programmatic event name passed to @ref Flow::Emit.
+     */
+    struct TriggerSpec {
+        TriggerKind kind = TriggerKind::Event;
+        std::string id;             ///< Button node id or event name.
+        Key key = Key::Unknown;     ///< Key code (Key triggers only).
+        int afterMs = 0;            ///< Delay in milliseconds (Auto triggers only).
+    };
+
+    /// @brief Describes one outgoing edge from a layer.
+    struct TransitionSpec {
+        TransitionId id;                       ///< Local to the parent layer.
+        LayerId to;                            ///< Target layer id, or @c "<back>" for Pop.
+        TransitionKind kind = TransitionKind::Replace;
+        std::optional<ClipName> outClip;       ///< Falls back to parent's defaultOutClip.
+        std::optional<ClipName> inClip;        ///< Falls back to target's defaultInClip.
+        TriggerSpec trigger;
+        std::vector<ActionRef> onStart;        ///< Side effects fired before TransitionOut.
+        std::vector<ActionRef> onMidpoint;     ///< Side effects fired after stack mutation.
+        std::vector<ActionRef> onComplete;     ///< Side effects fired after TransitionIn.
+    };
+
+    /// @brief Describes one node in the flow graph.
+    struct LayerSpec {
+        LayerId id;
+        std::optional<std::string> factory;    ///< null → default TransitioningLayer factory.
+        std::optional<std::string> layout;     ///< Path consumed by the default factory.
+        LayerKind kind = LayerKind::Screen;
+        Modality modality = Modality::Modal;       ///< Overlays only.
+        Construction construction = Construction::Fresh;
+        ClipName defaultOutClip = "transition_out";
+        ClipName defaultInClip = "transition_in";
+        std::vector<TransitionSpec> transitions;   ///< Outgoing edges from this layer.
+    };
+
+    /// @brief Default per-action timeout for transitions, in milliseconds.
+    inline constexpr int kDefaultActionTimeoutMs = 5000;
+
+    /// @brief Graph-wide policy fields.
+    struct GraphPolicy {
+        ReentryPolicy onReentry = ReentryPolicy::Queue;
+        int actionTimeoutMs = kDefaultActionTimeoutMs;
+    };
+
+    /**
+     * @brief A loaded, parsed flow graph.
+     *
+     * After loading, run @ref ValidateFlowGraph (or rely on @ref LoadResult)
+     * to surface structural problems. Cross-checks that require the live
+     * factory/action registries happen later in @ref Flow.
+     */
+    struct FlowGraph {
+        LayerId initial;
+        GraphPolicy policy;
+        std::vector<LayerSpec> layers;
+
+        /// @brief Returns the layer entry for @p id, or @c nullptr if none matches.
+        LayerSpec const* FindLayer(std::string_view id) const;
+    };
+
+    /// @brief One structural error reported by the graph validator.
+    struct GraphValidationError {
+        std::string layerId;       ///< Owning layer id, or empty for graph-level errors.
+        std::string transitionId;  ///< Owning transition id, or empty for layer-level errors.
+        std::string message;       ///< Human-readable description.
+    };
+
+    /**
+     * @brief Validates a parsed @ref FlowGraph against the structural rules.
+     *
+     * Checks performed:
+     * - The @c initial layer exists.
+     * - Every @c TransitionSpec::to references a known layer (or @c "<back>").
+     * - @c Push transitions target an @c Overlay-kind layer.
+     * - @c Pop transitions target @c "<back>".
+     * - Layer ids are unique.
+     * - Transition ids are unique within their parent layer.
+     *
+     * @return All errors found. Empty vector means the graph is structurally valid.
+     */
+    std::vector<GraphValidationError> ValidateFlowGraph(FlowGraph const& graph);
+
+    /// @brief Outcome of a flow-graph load attempt.
+    struct LoadResult {
+        std::optional<FlowGraph> graph;            ///< Populated on success.
+        std::vector<GraphValidationError> errors;  ///< All parsing and validation errors.
+
+        /// @brief Returns @c true if the graph parsed and validated cleanly.
+        bool ok() const { return graph.has_value() && errors.empty(); }
+    };
+
+    /**
+     * @brief Loads a flow graph from a JSON file on disk.
+     * @param path Filesystem path to a JSON document conforming to the flow-graph schema.
+     */
+    LoadResult LoadFlowGraphFromFile(std::filesystem::path const& path);
+
+    /**
+     * @brief Parses a flow graph from an already-loaded @c nlohmann::json value.
+     * @param root JSON document conforming to the flow-graph schema.
+     */
+    LoadResult LoadFlowGraphFromJson(nlohmann::json const& root);
+}

--- a/include/moth_ui/flow/iclickable.h
+++ b/include/moth_ui/flow/iclickable.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <functional>
+
+namespace moth_ui {
+    /**
+     * @brief Abstract interface for nodes that can be wired to a click action.
+     *
+     * Implemented by @ref UIButton and by any application-defined widget that
+     * wishes to be addressable from a flow graph's @c button trigger. The
+     * @ref flow::Flow runtime uses @c dynamic_cast<IClickable*> to locate a
+     * clickable node by id on a layout and install a callback that triggers
+     * the corresponding transition.
+     */
+    class IClickable {
+    public:
+        IClickable() = default;
+        IClickable(IClickable const&) = default;
+        IClickable(IClickable&&) = default;
+        IClickable& operator=(IClickable const&) = default;
+        IClickable& operator=(IClickable&&) = default;
+        virtual ~IClickable() = default;
+
+        /**
+         * @brief Installs the callback invoked when the widget is activated.
+         * @param action Callable to invoke; pass an empty @c std::function to clear.
+         */
+        virtual void SetClickAction(std::function<void()> action) = 0;
+    };
+}

--- a/include/moth_ui/flow/transition_participant.h
+++ b/include/moth_ui/flow/transition_participant.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "moth_ui/moth_ui_fwd.h"
+
+#include <functional>
+#include <memory>
+#include <string_view>
+
+namespace moth_ui::flow {
+
+    /**
+     * @brief Contract that a layer must satisfy to participate in @ref Flow transitions.
+     *
+     * The runtime drives transitions through this interface; whether the layer
+     * is layout-backed (@ref TransitioningLayer) or hand-coded
+     * (@ref CodeDrivenLayer) doesn't matter — both implement these four hooks.
+     *
+     * The @c tag parameter to @ref TransitionIn / @ref TransitionOut is an
+     * opaque string. A layout-backed layer interprets it as an animation clip
+     * name; a code-driven layer interprets it however it likes. The runtime
+     * does not inspect it.
+     */
+    class ITransitionParticipant {
+    public:
+        ITransitionParticipant() = default;
+        ITransitionParticipant(ITransitionParticipant const&) = default;
+        ITransitionParticipant(ITransitionParticipant&&) = default;
+        ITransitionParticipant& operator=(ITransitionParticipant const&) = default;
+        ITransitionParticipant& operator=(ITransitionParticipant&&) = default;
+        virtual ~ITransitionParticipant() = default;
+
+        /**
+         * @brief Called when the layer becomes the active screen/overlay.
+         *
+         * Fires after the layer has been added to the LayerStack but before
+         * any TransitionIn animation begins. Override to install button
+         * callbacks, take focus, start music cues, etc.
+         */
+        virtual void OnEnter() {}
+
+        /**
+         * @brief Called when the layer is about to leave the active set.
+         *
+         * Fires before the TransitionOut animation begins. Override to clear
+         * focus, release per-visit caches, etc.
+         */
+        virtual void OnExit() {}
+
+        /**
+         * @brief Plays the entry transition and signals @p done when complete.
+         * @param tag  Layer-specific tag (clip name for layout-backed layers).
+         * @param done Callback the layer must invoke exactly once when finished.
+         */
+        virtual void TransitionIn(std::string_view tag, std::function<void()> done) = 0;
+
+        /**
+         * @brief Plays the exit transition and signals @p done when complete.
+         * @param tag  Layer-specific tag (clip name for layout-backed layers).
+         * @param done Callback the layer must invoke exactly once when finished.
+         */
+        virtual void TransitionOut(std::string_view tag, std::function<void()> done) = 0;
+
+        /**
+         * @brief Returns the layout root for layout-backed layers, or @c nullptr.
+         *
+         * The @ref Flow runtime uses this to discover @ref IClickable nodes
+         * referenced by @c button triggers on outgoing transitions. Code-driven
+         * layers without a layout return @c nullptr; the runtime skips button
+         * binding for them automatically.
+         */
+        virtual std::shared_ptr<Group> GetUiRoot() const { return nullptr; }
+    };
+}

--- a/include/moth_ui/flow/transitioning_layer.h
+++ b/include/moth_ui/flow/transitioning_layer.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "moth_ui/events/event_animation.h"
+#include "moth_ui/flow/transition_participant.h"
+#include "moth_ui/layers/layer.h"
+#include "moth_ui/moth_ui_fwd.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace moth_ui::flow {
+
+    /**
+     * @brief Layer base for screens and overlays backed by a @c .mothui layout.
+     *
+     * Loads the layout at construction time, dispatches events into it, and
+     * plays clip-driven transitions. The @c tag arguments to
+     * @ref TransitionIn / @ref TransitionOut are interpreted as clip names:
+     * if the named clip exists on the layout the layer plays it and waits
+     * for the matching @c EventAnimationStopped before invoking @c done;
+     * otherwise @c done fires immediately.
+     *
+     * Most layers in a flow graph need no further subclass — the layout
+     * supplies the visuals, the graph drives navigation, and button
+     * triggers are wired by the @ref Flow runtime. Subclass only when a
+     * layer holds C++-side state or behaviour the graph can't express.
+     */
+    class TransitioningLayer : public Layer, public ITransitionParticipant {
+    public:
+        /**
+         * @brief Loads @p layoutPath into a new @ref Group root.
+         * @param context    Active rendering context.
+         * @param layoutPath Path to a @c .mothui layout file (may be empty).
+         */
+        TransitioningLayer(Context& context, std::string_view layoutPath);
+        TransitioningLayer(TransitioningLayer const&) = delete;
+        TransitioningLayer(TransitioningLayer&&) = delete;
+        TransitioningLayer& operator=(TransitioningLayer const&) = delete;
+        TransitioningLayer& operator=(TransitioningLayer&&) = delete;
+        ~TransitioningLayer() override;
+
+        /// @brief Resizes the layout root to fill the stack's render area.
+        void OnAddedToStack(LayerStack* stack) override;
+
+        /**
+         * @brief Broadcasts events through the layout root while the layer is active.
+         *
+         * The layer ignores events between @ref OnExit and the next
+         * @ref OnEnter so that input doesn't reach an out-animating screen.
+         */
+        bool OnEvent(Event const& event) override;
+
+        /// @brief Advances the layout root.
+        void Update(uint32_t ticks) override;
+
+        /// @brief Renders the layout root.
+        void Draw() override;
+
+        /// @brief Layouts authored to logical render coordinates.
+        bool UseRenderSize() const override { return true; }
+
+        /// @copydoc ITransitionParticipant::OnEnter
+        void OnEnter() override;
+
+        /// @copydoc ITransitionParticipant::OnExit
+        void OnExit() override;
+
+        /// @copydoc ITransitionParticipant::TransitionIn
+        void TransitionIn(std::string_view tag, std::function<void()> done) override;
+
+        /// @copydoc ITransitionParticipant::TransitionOut
+        void TransitionOut(std::string_view tag, std::function<void()> done) override;
+
+        /// @copydoc ITransitionParticipant::GetUiRoot
+        std::shared_ptr<Group> GetUiRoot() const override { return m_uiRoot; }
+
+    protected:
+        /// @brief Returns @c true if the layer is currently the active recipient of input.
+        bool IsActive() const { return m_active; }
+
+        /// @brief Access to the rendering context, for subclasses that need it.
+        Context& GetContext() const { return m_context; }
+
+        Context& m_context;
+        std::shared_ptr<Group> m_uiRoot;
+
+    private:
+        bool OnAnimationStopped(EventAnimationStopped const& event);
+        void PlayClip(std::string_view tag, std::function<void()> done);
+
+        bool m_active = false;
+        std::string m_pendingClipName;
+        std::function<void()> m_pendingDone;
+    };
+}

--- a/include/moth_ui/layers/layer.h
+++ b/include/moth_ui/layers/layer.h
@@ -65,6 +65,31 @@ namespace moth_ui {
          */
         virtual bool UseRenderSize() const { return false; }
 
+        /**
+         * @brief Returns @c true if this layer blocks input and updates of layers beneath it.
+         *
+         * When a modal layer is on the stack, the LayerStack stops dispatching
+         * events to layers below it (regardless of whether the modal layer
+         * itself consumed the event) and skips updating them. Use this for
+         * pause menus, blocking dialogs, and full-screen transitions.
+         *
+         * Layers above a modal layer continue to receive events and updates
+         * normally; only the topmost modal in the stack acts as the cutoff.
+         *
+         * Defaults to the value set by @ref SetModal (initially @c false).
+         * Subclasses may override to implement dynamic modality.
+         */
+        virtual bool IsModal() const { return m_modal; }
+
+        /**
+         * @brief Sets the static modal flag returned by the default @ref IsModal.
+         *
+         * The @ref flow::Flow runtime calls this on overlay creation when the
+         * @c LayerSpec.modality field is @c Modal. Subclasses that override
+         * @ref IsModal directly can ignore this method.
+         */
+        void SetModal(bool modal) { m_modal = modal; }
+
         Layer() = default;
         Layer(Layer const&) = delete;
         Layer(Layer&&) = delete;
@@ -74,5 +99,8 @@ namespace moth_ui {
 
     protected:
         LayerStack* m_layerStack = nullptr; ///< The stack this layer belongs to, or @c nullptr.
+
+    private:
+        bool m_modal = false;
     };
 }

--- a/include/moth_ui/layers/layer_stack.h
+++ b/include/moth_ui/layers/layer_stack.h
@@ -52,6 +52,18 @@ namespace moth_ui {
         void RemoveLayer(Layer* layer);
 
         /**
+         * @brief Removes a specific layer and returns ownership to the caller.
+         *
+         * Like @ref RemoveLayer but transfers the @c unique_ptr out instead
+         * of destroying it. Used by consumers (e.g. @ref flow::Flow caching)
+         * that want to keep a layer instance alive for later re-pushing.
+         *
+         * @param layer Raw pointer to the layer to detach.
+         * @return Owning pointer to the detached layer, or @c nullptr if not found.
+         */
+        std::unique_ptr<Layer> DetachLayer(Layer* layer);
+
+        /**
          * @brief Iterates layers in reverse order and dispatches the event.
          *
          * The first layer whose @c OnEvent returns @c true consumes the event.

--- a/include/moth_ui/moth_ui.h
+++ b/include/moth_ui/moth_ui.h
@@ -75,6 +75,7 @@
 // widgets (opt-in extension points on top of Group)
 #include "moth_ui/widgets/widget.h"
 #include "moth_ui/widgets/ui_button.h"
+#include "moth_ui/widgets/ui_scroll_view.h"
 
 // utils
 #include "moth_ui/utils/color.h"

--- a/include/moth_ui/moth_ui.h
+++ b/include/moth_ui/moth_ui.h
@@ -54,6 +54,14 @@
 #include "moth_ui/layers/layer.h"
 #include "moth_ui/layers/layer_stack.h"
 
+// flow (opt-in navigation utility)
+#include "moth_ui/flow/code_driven_layer.h"
+#include "moth_ui/flow/flow.h"
+#include "moth_ui/flow/flow_graph.h"
+#include "moth_ui/flow/iclickable.h"
+#include "moth_ui/flow/transition_participant.h"
+#include "moth_ui/flow/transitioning_layer.h"
+
 // nodes
 #include "moth_ui/nodes/group.h"
 #include "moth_ui/nodes/node.h"
@@ -61,9 +69,12 @@
 #include "moth_ui/nodes/node_image.h"
 #include "moth_ui/nodes/node_rect.h"
 #include "moth_ui/nodes/node_text.h"
-#include "moth_ui/nodes/widget.h"
 #include "moth_ui/nodes/node_flipbook.h"
 #include "moth_ui/nodes/node_gradient.h"
+
+// widgets (opt-in extension points on top of Group)
+#include "moth_ui/widgets/widget.h"
+#include "moth_ui/widgets/ui_button.h"
 
 // utils
 #include "moth_ui/utils/color.h"

--- a/include/moth_ui/moth_ui_fwd.h
+++ b/include/moth_ui/moth_ui_fwd.h
@@ -54,9 +54,15 @@ namespace moth_ui {
     class NodeClip;
     class NodeFlipbook;
     class NodeGradient;
+    class UIButton;
 
     template <typename T, typename BaseType>
     class Widget;
+
+    // -------------------------------------------------------------------------
+    // Clickable
+    // -------------------------------------------------------------------------
+    class IClickable;
 
     // -------------------------------------------------------------------------
     // Layout

--- a/include/moth_ui/nodes/group.h
+++ b/include/moth_ui/nodes/group.h
@@ -87,6 +87,24 @@ namespace moth_ui {
         void MoveChild(int fromIndex, int toIndex);
 
         /**
+         * @brief Sets the node that should receive events before normal broadcast.
+         *
+         * Stored as a weak reference, so a destroyed capturing node clears
+         * itself automatically. The capture state is normally consulted at the
+         * root of a UI tree (see @ref flow::TransitioningLayer::OnEvent);
+         * setting it on a non-root group has no effect unless the consumer of
+         * the tree reads from that group directly.
+         *
+         * @param node Node to receive events first, or @c nullptr to clear.
+         */
+        void SetCapturedNode(std::shared_ptr<Node> node);
+
+        /**
+         * @brief Returns the currently captured node, or @c nullptr if none / destroyed.
+         */
+        std::shared_ptr<Node> GetCapturedNode() const;
+
+        /**
          * @brief Returns whether an animation clip with the given name exists.
          * @param name Clip name to look up.
          * @return @c true if the clip exists in the layout's clip list.
@@ -186,6 +204,7 @@ namespace moth_ui {
 
     private:
         LayoutEntityGroup* m_typedLayout = nullptr;
+        std::weak_ptr<Node> m_capturedNode;
         void ReloadChildren();
     };
 }

--- a/include/moth_ui/nodes/node.h
+++ b/include/moth_ui/nodes/node.h
@@ -120,6 +120,37 @@ namespace moth_ui {
         /// @brief Returns the parent group, or @c nullptr if this is a root node.
         Group* GetParent() const { return m_parent; }
 
+        /**
+         * @brief Registers this node to receive events before normal broadcast.
+         *
+         * Walks up to the root @ref Group of this node's tree and stores a
+         * weak reference there. The root is the entry point that consults the
+         * capture (see @ref flow::TransitioningLayer::OnEvent): captured nodes
+         * see each event first and may consume it or let it fall through to
+         * the regular depth-first broadcast.
+         *
+         * Typical use is a widget entering an exclusive input mode (e.g. a
+         * text field beginning edit). The node must call
+         * @ref ReleaseInputCapture when leaving that mode; capture is also
+         * cleared automatically if the node is destroyed.
+         *
+         * No-op if the node has no parent (not yet attached to a tree).
+         */
+        void RequestInputCapture();
+
+        /**
+         * @brief Releases this node's input capture, if it currently holds it.
+         *
+         * No-op if the captured node on the root is a different node, or if
+         * the node has no parent.
+         */
+        void ReleaseInputCapture();
+
+        /**
+         * @brief Returns @c true if this node currently holds input capture on its tree.
+         */
+        bool HasInputCapture() const;
+
         /// @brief Returns the node's anchor/offset layout rectangle.
         LayoutRect& GetLayoutRect() { return m_layoutRect; }
 

--- a/include/moth_ui/nodes/node_text.h
+++ b/include/moth_ui/nodes/node_text.h
@@ -62,8 +62,14 @@ namespace moth_ui {
         /// @brief Returns the horizontal text alignment.
         TextHorizAlignment GetHorizontalAlignment() const { return m_horizontalAlignment; }
 
+        /// @brief Sets the horizontal text alignment.
+        void SetHorizontalAlignment(TextHorizAlignment alignment) { m_horizontalAlignment = alignment; }
+
         /// @brief Returns the vertical text alignment.
         TextVertAlignment GetVerticalAlignment() const { return m_verticalAlignment; }
+
+        /// @brief Sets the vertical text alignment.
+        void SetVerticalAlignment(TextVertAlignment alignment) { m_verticalAlignment = alignment; }
 
         /// @brief Returns @c true if a drop-shadow is rendered.
         bool IsDropShadow() const { return m_dropShadow; }

--- a/include/moth_ui/widgets/ui_button.h
+++ b/include/moth_ui/widgets/ui_button.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "moth_ui/events/event_mouse.h"
+#include "moth_ui/flow/iclickable.h"
+#include "moth_ui/widgets/widget.h"
+
+namespace moth_ui {
+    /**
+     * @brief Opt-in clickable button widget for moth_ui layouts.
+     *
+     * Recognises @c "idle", @c "hover", @c "press", and @c "activate" clips
+     * defined on its layout entity and switches between them in response to
+     * pointer input. Implements @ref IClickable so the @ref flow::Flow
+     * runtime (or any other consumer) can wire a callback that fires on the
+     * transition into the @c Activated state.
+     *
+     * Apps that need richer interaction (focus rings, controller navigation,
+     * audio cues) can implement their own widget that satisfies @ref IClickable
+     * and ignore this type entirely.
+     */
+    class UIButton : public Widget<UIButton>, public IClickable {
+    public:
+        /// @brief Class name under which this widget self-registers with @ref NodeFactory.
+        inline static char const* ClassName = "button";
+
+        /// @brief Visual / interaction state of the button.
+        enum class State {
+            Idle,       ///< Pointer not over the button.
+            Hovered,    ///< Pointer over the button, not pressed.
+            Pressed,    ///< Pointer pressed down inside the button.
+            Activated,  ///< Pointer released inside the button while pressed (click).
+        };
+
+        /**
+         * @brief Constructs a UIButton from a layout entity group.
+         * @param context Active rendering context.
+         * @param entity  Layout entity describing this button.
+         */
+        UIButton(Context& context, std::shared_ptr<LayoutEntityGroup> entity);
+        UIButton(UIButton const&) = delete;
+        UIButton(UIButton&&) = delete;
+        UIButton& operator=(UIButton const&) = delete;
+        UIButton& operator=(UIButton&&) = delete;
+        ~UIButton() override = default;
+
+        /**
+         * @brief Advances per-frame logic.
+         * @param ticks Elapsed time in milliseconds.
+         */
+        void Update(uint32_t ticks) override;
+
+        /**
+         * @brief Dispatches input events to the button's typed handlers.
+         * @param event Event to process.
+         * @return @c true if the event was consumed.
+         */
+        bool OnEvent(Event const& event) override;
+
+        /// @copydoc IClickable::SetClickAction
+        void SetClickAction(std::function<void()> action) override;
+
+        /// @brief Returns the button's current interaction state.
+        State GetState() const { return m_state; }
+
+    private:
+        bool OnMouseDown(EventMouseDown const& event);
+        bool OnMouseUp(EventMouseUp const& event);
+        bool OnMouseMove(EventMouseMove const& event);
+
+        void SetState(State state);
+
+        State m_state = State::Idle;
+        std::function<void()> m_clickAction;
+    };
+}

--- a/include/moth_ui/widgets/ui_scroll_view.h
+++ b/include/moth_ui/widgets/ui_scroll_view.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "moth_ui/widgets/widget.h"
+
+namespace moth_ui {
+    /**
+     * @brief Scrollable viewport widget for moth_ui layouts.
+     *
+     * A UIScrollView clips a single content node to its own bounds, scrolls it
+     * vertically with the mouse wheel, and culls pointer events that fall
+     * outside the viewport so content scrolled out of sight can neither be
+     * hovered nor clicked. It needs no @ref NodeClip child — the widget's own
+     * screen rectangle is the clip region.
+     *
+     * Assign the node to scroll with @ref SetContent. The content node must be
+     * sized to its full scrollable height (anchor it to the viewport top and
+     * give it an offset height equal to the total content); the widget clamps
+     * scrolling to @c contentHeight - @c viewportHeight.
+     *
+     * Self-registers under @c "scrollview" so layouts can name it as a class.
+     */
+    class UIScrollView : public Widget<UIScrollView> {
+    public:
+        /// @brief Class name under which this widget self-registers with @ref NodeFactory.
+        inline static char const* ClassName = "scrollview";
+
+        /**
+         * @brief Constructs a UIScrollView from a layout entity group.
+         * @param context Active rendering context.
+         * @param entity  Layout entity describing this widget.
+         */
+        UIScrollView(Context& context, std::shared_ptr<LayoutEntityGroup> entity);
+        UIScrollView(UIScrollView const&) = delete;
+        UIScrollView(UIScrollView&&) = delete;
+        UIScrollView& operator=(UIScrollView const&) = delete;
+        UIScrollView& operator=(UIScrollView&&) = delete;
+        ~UIScrollView() override = default;
+
+        /**
+         * @brief Sets the node scrolled within the viewport.
+         *
+         * Replaces any previous content, adds @p content as a child, records
+         * its current vertical offset as the unscrolled origin, and resets the
+         * scroll position to the top.
+         *
+         * @param content Node to scroll, sized to its full height. May be @c nullptr to clear.
+         */
+        void SetContent(std::shared_ptr<Node> content);
+
+        /// @brief Default pixels scrolled per wheel notch.
+        static constexpr float kDefaultScrollStep = 40.0f;
+
+        /// @brief Sets the pixels scrolled per wheel notch.
+        void SetScrollStep(float step) { m_scrollStep = step; }
+
+        /// @brief Returns the current scroll offset in pixels from the top.
+        float GetScrollOffset() const { return m_scrollY; }
+
+        /**
+         * @brief Intercepts the event walk to scroll and to cull off-viewport input.
+         * @param event Event to process.
+         * @return @c true if the event was consumed.
+         */
+        bool Broadcast(Event const& event) override;
+
+    protected:
+        void DrawInternal() override;
+
+    private:
+        // Adjusts the scroll position by @p deltaY pixels (clamped) and
+        // repositions the content node accordingly.
+        void ApplyScroll(float deltaY);
+        // Largest valid scroll offset: content height minus viewport height.
+        float MaxScroll() const;
+
+        std::shared_ptr<Node> m_content;
+        // The content's unscrolled vertical offset (top and bottom), captured
+        // in SetContent; scrolling subtracts m_scrollY from these.
+        float m_baseOffsetTop = 0.0f;
+        float m_baseOffsetBottom = 0.0f;
+        float m_scrollY = 0.0f;
+        float m_scrollStep = kDefaultScrollStep;
+    };
+}

--- a/include/moth_ui/widgets/ui_scroll_view.h
+++ b/include/moth_ui/widgets/ui_scroll_view.h
@@ -50,8 +50,14 @@ namespace moth_ui {
         /// @brief Default pixels scrolled per wheel notch.
         static constexpr float kDefaultScrollStep = 40.0f;
 
-        /// @brief Sets the pixels scrolled per wheel notch.
-        void SetScrollStep(float step) { m_scrollStep = step; }
+        /// @brief Sets the pixels scrolled per wheel notch. Ignores non-positive
+        /// or NaN values (the comparison is false for negative, zero, and NaN),
+        /// keeping the current step so wheel math can't be corrupted.
+        void SetScrollStep(float step) {
+            if (step > 0.0f) {
+                m_scrollStep = step;
+            }
+        }
 
         /// @brief Returns the current scroll offset in pixels from the top.
         float GetScrollOffset() const { return m_scrollY; }

--- a/include/moth_ui/widgets/widget.h
+++ b/include/moth_ui/widgets/widget.h
@@ -51,4 +51,21 @@ namespace moth_ui {
 
     template <typename T, typename BaseType>
     bool Widget<T, BaseType>::s_widgetIsRegistered_ = Widget<T, BaseType>::SelfRegister();
+
+    /**
+     * @brief Forces every bundled widget's self-registration to be linked in.
+     *
+     * Widgets in moth_ui register themselves with @ref NodeFactory through
+     * static initialisers (see @ref Widget::SelfRegister). When moth_ui is
+     * consumed as a static library and no application code names the widget
+     * types directly, the linker drops their translation units and the
+     * registrations never run — layouts that reference those widget classes
+     * silently fall back to plain @ref Group nodes.
+     *
+     * Apps that rely on any bundled widget must call this function once at
+     * startup (before loading any layouts). It is idempotent and has no
+     * runtime cost beyond the static initialisers it pulls in. Apps that
+     * supply their own widget set can ignore it.
+     */
+    void EnsureWidgetsRegistered();
 }

--- a/src/animation/animation_clip_controller.cpp
+++ b/src/animation/animation_clip_controller.cpp
@@ -19,7 +19,7 @@ namespace moth_ui {
             for (auto const& child : m_group->GetChildren()) {
                 child->GetAnimationController().SetFrame(m_frame);
             }
-            m_group->SendEvent(EventAnimationStarted(m_group->shared_from_this(), clip->name));
+            m_group->SendEvent(EventAnimationStarted(m_group->weak_from_this(), clip->name));
         }
     }
 
@@ -75,7 +75,7 @@ namespace moth_ui {
             }
 
             if (animationEnded) {
-                m_group->SendEvent(EventAnimationStopped(m_group->shared_from_this(), animationName));
+                m_group->SendEvent(EventAnimationStopped(m_group->weak_from_this(), animationName));
             }
         }
     }
@@ -87,7 +87,7 @@ namespace moth_ui {
         }
         for (auto& animEvent : layout->m_events) {
             if (static_cast<float>(animEvent->frame) > startFrame && static_cast<float>(animEvent->frame) <= endFrame) {
-                m_group->SendEvent(EventAnimation(m_group->shared_from_this(), animEvent->name));
+                m_group->SendEvent(EventAnimation(m_group->weak_from_this(), animEvent->name));
             }
         }
     }

--- a/src/flow/flow.cpp
+++ b/src/flow/flow.cpp
@@ -323,13 +323,16 @@ namespace moth_ui::flow {
             LayerSpec const* leavingSpec = m_active.back().spec;
             m_active.pop_back();
             if (leavingSpec != nullptr && leavingSpec->construction == Construction::Cached) {
-                // RemoveLayer takes a raw pointer and erases the unique_ptr.
-                // We can't reclaim ownership here, so cached + Pop currently
-                // destroys the instance. Logged for follow-up.
-                log::warn("Flow: cached layer '{}' destroyed by Pop (caching across Pop not yet supported)",
-                          leavingSpec->id);
+                // Detach the layer out of the stack so we can keep it alive
+                // in the cache for the next visit. RemoveLayer would destroy
+                // the unique_ptr.
+                auto cached = m_stack.DetachLayer(leaving);
+                if (cached) {
+                    m_cached[leavingSpec->id] = std::move(cached);
+                }
+            } else {
+                m_stack.RemoveLayer(leaving);
             }
-            m_stack.RemoveLayer(leaving);
             // Re-activate whatever layer the pop just revealed — its OnExit
             // was fired when this overlay was Push'd, so OnEnter is owed to
             // restore its active state.
@@ -338,57 +341,40 @@ namespace moth_ui::flow {
             }
             return;
         }
-        case TransitionKind::Push: {
-            if (m_activeTransition.targetSpec == nullptr) {
-                return;
-            }
-            auto owned = BuildLayer(*m_activeTransition.targetSpec);
-            if (!owned) {
-                return;
-            }
-            Layer* raw = owned.get();
-            ITransitionParticipant* participant = AsParticipant(raw);
-            m_activeTransition.targetLayer = raw;
-            m_activeTransition.targetParticipant = participant;
-            bool const modal = m_activeTransition.targetSpec->kind == LayerKind::Overlay
-                && m_activeTransition.targetSpec->modality == Modality::Modal;
-            raw->SetModal(modal);
-            m_stack.PushLayer(std::move(owned));
-            m_active.push_back({ m_activeTransition.targetSpec, raw, participant });
-            InstallButtonBindings(*m_activeTransition.targetSpec, participant);
-            if (participant != nullptr) {
-                participant->OnEnter();
+        case TransitionKind::Push:
+            if (m_activeTransition.targetSpec != nullptr) {
+                PushTargetLayer(*m_activeTransition.targetSpec);
             }
             return;
-        }
-        case TransitionKind::Replace: {
+        case TransitionKind::Replace:
             // Pop any overlays sitting above the source plus the source itself.
             for (auto it = m_active.rbegin(); it != m_active.rend(); ++it) {
                 m_stack.RemoveLayer(it->layer);
             }
             m_active.clear();
-            if (m_activeTransition.targetSpec == nullptr) {
-                return;
-            }
-            auto owned = BuildLayer(*m_activeTransition.targetSpec);
-            if (!owned) {
-                return;
-            }
-            Layer* raw = owned.get();
-            ITransitionParticipant* participant = AsParticipant(raw);
-            m_activeTransition.targetLayer = raw;
-            m_activeTransition.targetParticipant = participant;
-            bool const modal = m_activeTransition.targetSpec->kind == LayerKind::Overlay
-                && m_activeTransition.targetSpec->modality == Modality::Modal;
-            raw->SetModal(modal);
-            m_stack.PushLayer(std::move(owned));
-            m_active.push_back({ m_activeTransition.targetSpec, raw, participant });
-            InstallButtonBindings(*m_activeTransition.targetSpec, participant);
-            if (participant != nullptr) {
-                participant->OnEnter();
+            if (m_activeTransition.targetSpec != nullptr) {
+                PushTargetLayer(*m_activeTransition.targetSpec);
             }
             return;
         }
+    }
+
+    void Flow::PushTargetLayer(LayerSpec const& spec) {
+        auto owned = BuildLayer(spec);
+        if (!owned) {
+            return;
+        }
+        Layer* raw = owned.get();
+        ITransitionParticipant* participant = AsParticipant(raw);
+        m_activeTransition.targetLayer = raw;
+        m_activeTransition.targetParticipant = participant;
+        bool const modal = spec.kind == LayerKind::Overlay && spec.modality == Modality::Modal;
+        raw->SetModal(modal);
+        m_stack.PushLayer(std::move(owned));
+        m_active.push_back({ &spec, raw, participant });
+        InstallButtonBindings(spec, participant);
+        if (participant != nullptr) {
+            participant->OnEnter();
         }
     }
 

--- a/src/flow/flow.cpp
+++ b/src/flow/flow.cpp
@@ -1,0 +1,446 @@
+#include "common.h"
+#include "moth_ui/flow/flow.h"
+
+#include "moth_ui/events/event_dispatch.h"
+#include "moth_ui/flow/transition_participant.h"
+#include "moth_ui/flow/transitioning_layer.h"
+#include "moth_ui/flow/iclickable.h"
+#include "moth_ui/ilogger.h"
+#include "moth_ui/layers/layer_stack.h"
+#include "moth_ui/nodes/group.h"
+
+#include <utility>
+
+namespace moth_ui::flow {
+
+    namespace {
+        ITransitionParticipant* AsParticipant(Layer* layer) {
+            return dynamic_cast<ITransitionParticipant*>(layer);
+        }
+
+        std::pair<std::string_view, std::string_view> SplitQualifiedId(std::string_view qualifiedId) {
+            auto dot = qualifiedId.find('.');
+            if (dot == std::string_view::npos) {
+                return { qualifiedId, {} };
+            }
+            return { qualifiedId.substr(0, dot), qualifiedId.substr(dot + 1) };
+        }
+    }
+
+    Flow::Flow(LayerStack& stack, Context& context, FlowGraph graph)
+        : m_stack(stack)
+        , m_context(context)
+        , m_graph(std::move(graph)) {
+    }
+
+    Flow::~Flow() = default;
+
+    void Flow::RegisterFactory(std::string name, LayerFactory factory) {
+        m_factories[std::move(name)] = std::move(factory);
+    }
+
+    void Flow::RegisterAction(std::string name, Action action) {
+        m_actions[std::move(name)] = std::move(action);
+    }
+
+    std::unique_ptr<Layer> Flow::BuildLayer(LayerSpec const& spec) {
+        if (spec.construction == Construction::Cached) {
+            auto it = m_cached.find(spec.id);
+            if (it != m_cached.end() && it->second) {
+                return std::move(it->second);
+            }
+        }
+        if (spec.factory.has_value()) {
+            auto fit = m_factories.find(*spec.factory);
+            if (fit == m_factories.end()) {
+                log::error("Flow: unknown factory '{}' for layer '{}'", *spec.factory, spec.id);
+                return nullptr;
+            }
+            return fit->second(m_context, spec);
+        }
+        std::string_view layoutPath = spec.layout.has_value() ? std::string_view(*spec.layout) : std::string_view{};
+        return std::make_unique<TransitioningLayer>(m_context, layoutPath);
+    }
+
+    void Flow::InstallButtonBindings(LayerSpec const& spec, ITransitionParticipant* participant) {
+        if (participant == nullptr) {
+            return;
+        }
+        auto root = participant->GetUiRoot();
+        if (!root) {
+            return;
+        }
+        for (auto const& transition : spec.transitions) {
+            if (transition.trigger.kind != TriggerKind::Button) {
+                continue;
+            }
+            auto child = root->FindChild(transition.trigger.id);
+            auto* clickable = dynamic_cast<IClickable*>(child.get());
+            if (clickable == nullptr) {
+                log::warn("Flow: button trigger node '{}' on layer '{}' is missing or not IClickable",
+                          transition.trigger.id, spec.id);
+                continue;
+            }
+            std::string qualifiedId = spec.id + "." + transition.id;
+            clickable->SetClickAction([this, qualifiedId] {
+                Trigger(qualifiedId);
+            });
+        }
+    }
+
+    void Flow::Start() {
+        if (m_started) {
+            return;
+        }
+        m_started = true;
+        auto const* spec = m_graph.FindLayer(m_graph.initial);
+        if (spec == nullptr) {
+            log::error("Flow: initial layer '{}' not found", m_graph.initial);
+            return;
+        }
+        auto owned = BuildLayer(*spec);
+        if (!owned) {
+            return;
+        }
+        Layer* raw = owned.get();
+        ITransitionParticipant* participant = AsParticipant(raw);
+        bool const modal = spec->kind == LayerKind::Overlay
+            && spec->modality == Modality::Modal;
+        raw->SetModal(modal);
+        m_stack.PushLayer(std::move(owned));
+        m_active.push_back({ spec, raw, participant });
+        InstallButtonBindings(*spec, participant);
+        if (participant != nullptr) {
+            participant->OnEnter();
+            participant->TransitionIn(spec->defaultInClip, []{});
+        }
+    }
+
+    TransitionSpec const* Flow::FindTransition(std::string_view qualifiedId, LayerSpec const*& outLayer) const {
+        auto [layerId, transitionId] = SplitQualifiedId(qualifiedId);
+        if (layerId.empty() || transitionId.empty()) {
+            return nullptr;
+        }
+        auto const* spec = m_graph.FindLayer(layerId);
+        if (spec == nullptr) {
+            return nullptr;
+        }
+        for (auto const& transition : spec->transitions) {
+            if (transition.id == transitionId) {
+                outLayer = spec;
+                return &transition;
+            }
+        }
+        return nullptr;
+    }
+
+    void Flow::Trigger(std::string_view qualifiedId) {
+        LayerSpec const* source = nullptr;
+        auto const* transition = FindTransition(qualifiedId, source);
+        if (transition == nullptr) {
+            log::warn("Flow: Trigger('{}') references unknown transition", qualifiedId);
+            return;
+        }
+        if (m_phase != Phase::Idle) {
+            switch (m_graph.policy.onReentry) {
+            case ReentryPolicy::Reject:
+                log::info("Flow: Trigger('{}') rejected (re-entry policy)", qualifiedId);
+                return;
+            case ReentryPolicy::Queue:
+                if (!m_pendingTrigger.has_value()) {
+                    m_pendingTrigger = std::string(qualifiedId);
+                }
+                return;
+            case ReentryPolicy::Coalesce:
+                m_pendingTrigger = std::string(qualifiedId);
+                return;
+            }
+        }
+        BeginTransition(*source, *transition);
+    }
+
+    void Flow::Emit(std::string_view eventName) {
+        auto* top = TopmostActive();
+        if (top == nullptr || top->spec == nullptr) {
+            return;
+        }
+        for (auto const& transition : top->spec->transitions) {
+            if (transition.trigger.kind == TriggerKind::Event && transition.trigger.id == eventName) {
+                Trigger(top->spec->id + "." + transition.id);
+                return;
+            }
+        }
+    }
+
+    bool Flow::OnEvent(Event const& event) {
+        EventDispatch dispatch(event);
+        dispatch.Dispatch(this, &Flow::DispatchKey);
+        return dispatch.GetHandled();
+    }
+
+    bool Flow::DispatchKey(EventKey const& event) {
+        if (event.GetAction() != KeyAction::Down) {
+            return false;
+        }
+        auto* top = TopmostActive();
+        if (top == nullptr || top->spec == nullptr) {
+            return false;
+        }
+        for (auto const& transition : top->spec->transitions) {
+            if (transition.trigger.kind == TriggerKind::Key && transition.trigger.key == event.GetKey()) {
+                Trigger(top->spec->id + "." + transition.id);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    Flow::StackEntry* Flow::TopmostActive() {
+        if (m_active.empty()) {
+            return nullptr;
+        }
+        return &m_active.back();
+    }
+
+    LayerSpec const* Flow::ResolvePopTarget() const {
+        if (m_active.size() < 2) {
+            return nullptr;
+        }
+        return m_active[m_active.size() - 2].spec;
+    }
+
+    void Flow::BeginTransition(LayerSpec const& source, TransitionSpec const& transition) {
+        m_activeTransition = ActiveTransition{};
+        m_activeTransition.sourceSpec = &source;
+        m_activeTransition.spec = &transition;
+        if (transition.kind == TransitionKind::Pop) {
+            m_activeTransition.targetSpec = ResolvePopTarget();
+        } else if (transition.to != kBackTarget) {
+            m_activeTransition.targetSpec = m_graph.FindLayer(transition.to);
+        }
+
+        // Locate the source layer in our active set. For a Replace fired from
+        // inside an overlay, the source is the overlay (topmost); the runtime
+        // will pop intervening overlays during stack mutation.
+        for (auto const& entry : m_active) {
+            if (entry.spec == &source) {
+                m_activeTransition.sourceLayer = entry.layer;
+                m_activeTransition.sourceParticipant = entry.participant;
+            }
+        }
+        if (m_activeTransition.sourceParticipant != nullptr) {
+            m_activeTransition.sourceParticipant->OnExit();
+        }
+        EnterPhase(Phase::OnStart);
+    }
+
+    void Flow::EnterPhase(Phase next) {
+        m_phase = next;
+        m_phaseDone = false;
+        m_activeTransition.phaseElapsedMs = 0;
+        m_activeTransition.actionInFlight = false;
+        switch (next) {
+        case Phase::Idle:
+            return;
+        case Phase::OnStart:
+            m_activeTransition.actionQueue = m_activeTransition.spec->onStart;
+            RunNextAction();
+            return;
+        case Phase::OutAnimating: {
+            if (m_activeTransition.spec->kind == TransitionKind::Push) {
+                m_phaseDone = true;
+                return;
+            }
+            std::string const& clip = m_activeTransition.spec->outClip.has_value()
+                ? *m_activeTransition.spec->outClip
+                : m_activeTransition.sourceSpec->defaultOutClip;
+            if (m_activeTransition.sourceParticipant != nullptr) {
+                m_activeTransition.sourceParticipant->TransitionOut(clip, [this]{ m_phaseDone = true; });
+            } else {
+                m_phaseDone = true;
+            }
+            return;
+        }
+        case Phase::DoStackMutation:
+            DoStackMutation();
+            m_phaseDone = true;
+            return;
+        case Phase::OnMidpoint:
+            m_activeTransition.actionQueue = m_activeTransition.spec->onMidpoint;
+            RunNextAction();
+            return;
+        case Phase::InAnimating: {
+            if (m_activeTransition.spec->kind == TransitionKind::Pop) {
+                m_phaseDone = true;
+                return;
+            }
+            if (m_activeTransition.targetParticipant == nullptr || m_activeTransition.targetSpec == nullptr) {
+                m_phaseDone = true;
+                return;
+            }
+            std::string const& clip = m_activeTransition.spec->inClip.has_value()
+                ? *m_activeTransition.spec->inClip
+                : m_activeTransition.targetSpec->defaultInClip;
+            m_activeTransition.targetParticipant->TransitionIn(clip, [this]{ m_phaseDone = true; });
+            return;
+        }
+        case Phase::OnComplete:
+            m_activeTransition.actionQueue = m_activeTransition.spec->onComplete;
+            RunNextAction();
+            return;
+        }
+    }
+
+    void Flow::RunNextAction() {
+        if (m_activeTransition.actionQueue.empty()) {
+            m_phaseDone = true;
+            return;
+        }
+        ActionRef const name = m_activeTransition.actionQueue.front();
+        m_activeTransition.actionQueue.erase(m_activeTransition.actionQueue.begin());
+        auto it = m_actions.find(name);
+        if (it == m_actions.end()) {
+            log::warn("Flow: action '{}' not registered, skipping", name);
+            RunNextAction();
+            return;
+        }
+        m_activeTransition.actionInFlight = true;
+        m_activeTransition.phaseElapsedMs = 0;
+        it->second([this] {
+            m_activeTransition.actionInFlight = false;
+            RunNextAction();
+        });
+    }
+
+    void Flow::DoStackMutation() {
+        auto const& t = *m_activeTransition.spec;
+        switch (t.kind) {
+        case TransitionKind::Pop: {
+            if (m_active.empty()) {
+                return;
+            }
+            Layer* leaving = m_active.back().layer;
+            LayerSpec const* leavingSpec = m_active.back().spec;
+            m_active.pop_back();
+            if (leavingSpec != nullptr && leavingSpec->construction == Construction::Cached) {
+                // RemoveLayer takes a raw pointer and erases the unique_ptr.
+                // We can't reclaim ownership here, so cached + Pop currently
+                // destroys the instance. Logged for follow-up.
+                log::warn("Flow: cached layer '{}' destroyed by Pop (caching across Pop not yet supported)",
+                          leavingSpec->id);
+            }
+            m_stack.RemoveLayer(leaving);
+            // Re-activate whatever layer the pop just revealed — its OnExit
+            // was fired when this overlay was Push'd, so OnEnter is owed to
+            // restore its active state.
+            if (!m_active.empty() && m_active.back().participant != nullptr) {
+                m_active.back().participant->OnEnter();
+            }
+            return;
+        }
+        case TransitionKind::Push: {
+            if (m_activeTransition.targetSpec == nullptr) {
+                return;
+            }
+            auto owned = BuildLayer(*m_activeTransition.targetSpec);
+            if (!owned) {
+                return;
+            }
+            Layer* raw = owned.get();
+            ITransitionParticipant* participant = AsParticipant(raw);
+            m_activeTransition.targetLayer = raw;
+            m_activeTransition.targetParticipant = participant;
+            bool const modal = m_activeTransition.targetSpec->kind == LayerKind::Overlay
+                && m_activeTransition.targetSpec->modality == Modality::Modal;
+            raw->SetModal(modal);
+            m_stack.PushLayer(std::move(owned));
+            m_active.push_back({ m_activeTransition.targetSpec, raw, participant });
+            InstallButtonBindings(*m_activeTransition.targetSpec, participant);
+            if (participant != nullptr) {
+                participant->OnEnter();
+            }
+            return;
+        }
+        case TransitionKind::Replace: {
+            // Pop any overlays sitting above the source plus the source itself.
+            for (auto it = m_active.rbegin(); it != m_active.rend(); ++it) {
+                m_stack.RemoveLayer(it->layer);
+            }
+            m_active.clear();
+            if (m_activeTransition.targetSpec == nullptr) {
+                return;
+            }
+            auto owned = BuildLayer(*m_activeTransition.targetSpec);
+            if (!owned) {
+                return;
+            }
+            Layer* raw = owned.get();
+            ITransitionParticipant* participant = AsParticipant(raw);
+            m_activeTransition.targetLayer = raw;
+            m_activeTransition.targetParticipant = participant;
+            bool const modal = m_activeTransition.targetSpec->kind == LayerKind::Overlay
+                && m_activeTransition.targetSpec->modality == Modality::Modal;
+            raw->SetModal(modal);
+            m_stack.PushLayer(std::move(owned));
+            m_active.push_back({ m_activeTransition.targetSpec, raw, participant });
+            InstallButtonBindings(*m_activeTransition.targetSpec, participant);
+            if (participant != nullptr) {
+                participant->OnEnter();
+            }
+            return;
+        }
+        }
+    }
+
+    void Flow::AdvancePhase() {
+        switch (m_phase) {
+        case Phase::Idle:
+            return;
+        case Phase::OnStart:       EnterPhase(Phase::OutAnimating);    return;
+        case Phase::OutAnimating:  EnterPhase(Phase::DoStackMutation); return;
+        case Phase::DoStackMutation: EnterPhase(Phase::OnMidpoint);    return;
+        case Phase::OnMidpoint:    EnterPhase(Phase::InAnimating);     return;
+        case Phase::InAnimating:   EnterPhase(Phase::OnComplete);      return;
+        case Phase::OnComplete:    FinishTransition();                 return;
+        }
+    }
+
+    void Flow::FinishTransition() {
+        m_phase = Phase::Idle;
+        m_activeTransition = ActiveTransition{};
+        if (m_pendingTrigger.has_value()) {
+            std::string next = std::move(*m_pendingTrigger);
+            m_pendingTrigger.reset();
+            Trigger(next);
+        }
+    }
+
+    void Flow::Tick(uint32_t ticks) {
+        if (m_phase == Phase::Idle) {
+            return;
+        }
+        m_activeTransition.phaseElapsedMs += ticks;
+
+        // Per-phase timeout watchdog: applies to async work (animations and
+        // in-flight actions). Synchronous phases (DoStackMutation) finish in
+        // a single step and never sit here.
+        bool const isAsync = m_activeTransition.actionInFlight
+            || m_phase == Phase::OutAnimating
+            || m_phase == Phase::InAnimating;
+        int const timeoutMs = m_graph.policy.actionTimeoutMs;
+        if (isAsync && timeoutMs > 0 && static_cast<int>(m_activeTransition.phaseElapsedMs) >= timeoutMs) {
+            log::warn("Flow: phase timed out after {} ms, force-advancing", timeoutMs);
+            m_phaseDone = true;
+            m_activeTransition.actionInFlight = false;
+        }
+
+        // Drain every phase that finishes synchronously in this same tick.
+        // The loop only mutates the layer stack from inside Tick (never from
+        // event handlers), so re-entry is safe. It exits as soon as a phase
+        // becomes async (animation in flight, action awaiting done) or the
+        // transition reaches Idle.
+        while (m_phaseDone && m_phase != Phase::Idle) {
+            AdvancePhase();
+        }
+    }
+}

--- a/src/flow/flow_graph.cpp
+++ b/src/flow/flow_graph.cpp
@@ -292,26 +292,37 @@ namespace moth_ui::flow {
             return result;
         }
 
-        ParseContext ctx{ result.errors, "", "" };
+        // Catch-all for nlohmann::json type mismatches that the per-field
+        // checks miss (e.g. a string field that is actually a number). The
+        // Parse* helpers use j.value() / j.at().get<T>(), both of which
+        // throw type_error on a wrong-typed value rather than returning a
+        // default. Without this barrier those exceptions would unwind into
+        // application code.
         FlowGraph graph;
-        graph.initial = root.value("initial", "");
-        if (graph.initial.empty()) {
-            ctx.Error("graph missing 'initial'");
-        }
-        if (root.contains("policy")) {
-            graph.policy = ParsePolicy(root.at("policy"), ctx);
-        }
-        if (root.contains("layers")) {
-            auto const& arr = root.at("layers");
-            if (!arr.is_array()) {
-                ctx.Error("'layers' must be an array");
-            } else {
-                for (auto const& item : arr) {
-                    graph.layers.push_back(ParseLayer(item, ctx));
-                }
+        try {
+            ParseContext ctx{ result.errors, "", "" };
+            graph.initial = root.value("initial", "");
+            if (graph.initial.empty()) {
+                ctx.Error("graph missing 'initial'");
             }
-        } else {
-            ctx.Error("graph missing 'layers'");
+            if (root.contains("policy")) {
+                graph.policy = ParsePolicy(root.at("policy"), ctx);
+            }
+            if (root.contains("layers")) {
+                auto const& arr = root.at("layers");
+                if (!arr.is_array()) {
+                    ctx.Error("'layers' must be an array");
+                } else {
+                    for (auto const& item : arr) {
+                        graph.layers.push_back(ParseLayer(item, ctx));
+                    }
+                }
+            } else {
+                ctx.Error("graph missing 'layers'");
+            }
+        } catch (nlohmann::json::exception const& e) {
+            result.errors.push_back({ "", "", fmt::format("JSON type error: {}", e.what()) });
+            return result;
         }
 
         auto structural = ValidateFlowGraph(graph);

--- a/src/flow/flow_graph.cpp
+++ b/src/flow/flow_graph.cpp
@@ -1,0 +1,341 @@
+#include "common.h"
+#include "moth_ui/flow/flow_graph.h"
+
+#include <fmt/format.h>
+#include <magic_enum.hpp>
+
+#include <fstream>
+#include <set>
+
+namespace moth_ui::flow {
+
+    LayerSpec const* FlowGraph::FindLayer(std::string_view id) const {
+        for (auto const& layer : layers) {
+            if (layer.id == id) {
+                return &layer;
+            }
+        }
+        return nullptr;
+    }
+
+    namespace {
+
+        template <typename Enum>
+        std::optional<Enum> ParseEnumCaseInsensitive(std::string_view name) {
+            return magic_enum::enum_cast<Enum>(name, magic_enum::case_insensitive);
+        }
+
+        struct ParseContext {
+            std::vector<GraphValidationError>& errors;
+            std::string layerId;
+            std::string transitionId;
+
+            void Error(std::string message) {
+                errors.push_back({ layerId, transitionId, std::move(message) });
+            }
+        };
+
+        TriggerSpec ParseTrigger(nlohmann::json const& j, ParseContext& ctx) {
+            TriggerSpec spec;
+            if (!j.is_object()) {
+                ctx.Error("trigger must be an object");
+                return spec;
+            }
+            std::string typeStr = j.value("type", "");
+            auto kind = ParseEnumCaseInsensitive<TriggerKind>(typeStr);
+            if (!kind) {
+                ctx.Error(fmt::format("trigger has unknown type '{}'", typeStr));
+                return spec;
+            }
+            spec.kind = *kind;
+            switch (spec.kind) {
+            case TriggerKind::Button:
+            case TriggerKind::Event:
+                spec.id = j.value("id", "");
+                if (spec.id.empty() && spec.kind == TriggerKind::Button) {
+                    ctx.Error("button trigger missing 'id'");
+                } else if (spec.id.empty() && spec.kind == TriggerKind::Event) {
+                    spec.id = j.value("name", "");
+                    if (spec.id.empty()) {
+                        ctx.Error("event trigger missing 'name'");
+                    }
+                }
+                break;
+            case TriggerKind::Key: {
+                std::string keyName = j.value("key", "");
+                auto key = ParseEnumCaseInsensitive<Key>(keyName);
+                if (!key) {
+                    ctx.Error(fmt::format("key trigger has unknown key '{}'", keyName));
+                    break;
+                }
+                spec.key = *key;
+                break;
+            }
+            case TriggerKind::Auto:
+                spec.afterMs = j.value("afterMs", 0);
+                if (spec.afterMs < 0) {
+                    ctx.Error("auto trigger 'afterMs' must be >= 0");
+                }
+                break;
+            }
+            return spec;
+        }
+
+        std::vector<ActionRef> ParseActionList(nlohmann::json const& j, ParseContext& ctx, char const* fieldName) {
+            std::vector<ActionRef> out;
+            if (j.is_null() || !j.contains(fieldName)) {
+                return out;
+            }
+            auto const& arr = j.at(fieldName);
+            if (!arr.is_array()) {
+                ctx.Error(fmt::format("'{}' must be an array of action names", fieldName));
+                return out;
+            }
+            for (auto const& item : arr) {
+                if (!item.is_string()) {
+                    ctx.Error(fmt::format("'{}' entries must be strings", fieldName));
+                    continue;
+                }
+                out.push_back(item.get<std::string>());
+            }
+            return out;
+        }
+
+        TransitionSpec ParseTransition(nlohmann::json const& j, ParseContext& ctx) {
+            TransitionSpec spec;
+            if (!j.is_object()) {
+                ctx.Error("transition entry must be an object");
+                return spec;
+            }
+            spec.id = j.value("id", "");
+            ctx.transitionId = spec.id;
+            if (spec.id.empty()) {
+                ctx.Error("transition missing 'id'");
+            }
+            spec.to = j.value("to", "");
+            if (spec.to.empty()) {
+                ctx.Error("transition missing 'to'");
+            }
+            std::string kindStr = j.value("kind", "replace");
+            auto kind = ParseEnumCaseInsensitive<TransitionKind>(kindStr);
+            if (!kind) {
+                ctx.Error(fmt::format("transition has unknown kind '{}'", kindStr));
+            } else {
+                spec.kind = *kind;
+            }
+            if (j.contains("outClip") && !j.at("outClip").is_null()) {
+                spec.outClip = j.at("outClip").get<std::string>();
+            }
+            if (j.contains("inClip") && !j.at("inClip").is_null()) {
+                spec.inClip = j.at("inClip").get<std::string>();
+            }
+            if (j.contains("trigger")) {
+                spec.trigger = ParseTrigger(j.at("trigger"), ctx);
+            } else {
+                ctx.Error("transition missing 'trigger'");
+            }
+            spec.onStart = ParseActionList(j, ctx, "onStart");
+            spec.onMidpoint = ParseActionList(j, ctx, "onMidpoint");
+            spec.onComplete = ParseActionList(j, ctx, "onComplete");
+            ctx.transitionId.clear();
+            return spec;
+        }
+
+        LayerSpec ParseLayer(nlohmann::json const& j, ParseContext& ctx) {
+            LayerSpec spec;
+            if (!j.is_object()) {
+                ctx.Error("layer entry must be an object");
+                return spec;
+            }
+            spec.id = j.value("id", "");
+            ctx.layerId = spec.id;
+            if (spec.id.empty()) {
+                ctx.Error("layer missing 'id'");
+            }
+            if (j.contains("factory") && !j.at("factory").is_null()) {
+                spec.factory = j.at("factory").get<std::string>();
+            }
+            if (j.contains("layout") && !j.at("layout").is_null()) {
+                spec.layout = j.at("layout").get<std::string>();
+            }
+            std::string kindStr = j.value("kind", "screen");
+            auto kind = ParseEnumCaseInsensitive<LayerKind>(kindStr);
+            if (!kind) {
+                ctx.Error(fmt::format("layer has unknown kind '{}'", kindStr));
+            } else {
+                spec.kind = *kind;
+            }
+            std::string modalityStr = j.value("modality", "modal");
+            auto modality = ParseEnumCaseInsensitive<Modality>(modalityStr);
+            if (!modality) {
+                ctx.Error(fmt::format("layer has unknown modality '{}'", modalityStr));
+            } else {
+                spec.modality = *modality;
+            }
+            std::string constructionStr = j.value("construction", "fresh");
+            auto construction = ParseEnumCaseInsensitive<Construction>(constructionStr);
+            if (!construction) {
+                ctx.Error(fmt::format("layer has unknown construction '{}'", constructionStr));
+            } else {
+                spec.construction = *construction;
+            }
+            spec.defaultOutClip = j.value("defaultOutClip", spec.defaultOutClip);
+            spec.defaultInClip = j.value("defaultInClip", spec.defaultInClip);
+            if (j.contains("transitions")) {
+                auto const& arr = j.at("transitions");
+                if (!arr.is_array()) {
+                    ctx.Error("'transitions' must be an array");
+                } else {
+                    for (auto const& item : arr) {
+                        spec.transitions.push_back(ParseTransition(item, ctx));
+                    }
+                }
+            }
+            ctx.layerId.clear();
+            return spec;
+        }
+
+        GraphPolicy ParsePolicy(nlohmann::json const& j, ParseContext& ctx) {
+            GraphPolicy policy;
+            if (j.is_null()) {
+                return policy;
+            }
+            if (!j.is_object()) {
+                ctx.Error("'policy' must be an object");
+                return policy;
+            }
+            std::string reentryStr = j.value("onReentry", "queue");
+            auto reentry = ParseEnumCaseInsensitive<ReentryPolicy>(reentryStr);
+            if (!reentry) {
+                ctx.Error(fmt::format("policy has unknown onReentry '{}'", reentryStr));
+            } else {
+                policy.onReentry = *reentry;
+            }
+            policy.actionTimeoutMs = j.value("actionTimeoutMs", policy.actionTimeoutMs);
+            if (policy.actionTimeoutMs < 0) {
+                ctx.Error("policy 'actionTimeoutMs' must be >= 0");
+            }
+            return policy;
+        }
+    }
+
+    namespace {
+        using ErrorReporter = std::function<void(std::string, std::string, std::string)>;
+
+        void ValidateLayerIdUniqueness(FlowGraph const& graph, ErrorReporter const& report) {
+            std::set<std::string> seen;
+            for (auto const& layer : graph.layers) {
+                if (layer.id.empty()) {
+                    continue;
+                }
+                if (!seen.insert(layer.id).second) {
+                    report(layer.id, "", fmt::format("duplicate layer id '{}'", layer.id));
+                }
+            }
+        }
+
+        void ValidateInitial(FlowGraph const& graph, ErrorReporter const& report) {
+            if (graph.initial.empty()) {
+                report("", "", "graph 'initial' is empty");
+            } else if (graph.FindLayer(graph.initial) == nullptr) {
+                report("", "", fmt::format("graph 'initial' references unknown layer '{}'", graph.initial));
+            }
+        }
+
+        void ValidateTransitionTarget(FlowGraph const& graph, LayerSpec const& layer, TransitionSpec const& transition, ErrorReporter const& report) {
+            bool const isBack = transition.to == kBackTarget;
+            if (transition.kind == TransitionKind::Pop && !isBack) {
+                report(layer.id, transition.id, "Pop transitions must target '<back>'");
+            }
+            if (transition.kind != TransitionKind::Pop && isBack) {
+                report(layer.id, transition.id, "only Pop transitions may target '<back>'");
+            }
+            if (isBack || transition.to.empty()) {
+                return;
+            }
+            auto const* target = graph.FindLayer(transition.to);
+            if (target == nullptr) {
+                report(layer.id, transition.id, fmt::format("transition targets unknown layer '{}'", transition.to));
+            } else if (transition.kind == TransitionKind::Push && target->kind != LayerKind::Overlay) {
+                report(layer.id, transition.id, fmt::format("Push must target an Overlay; '{}' is a Screen", transition.to));
+            }
+        }
+
+        void ValidateLayerTransitions(FlowGraph const& graph, LayerSpec const& layer, ErrorReporter const& report) {
+            std::set<std::string> seenIds;
+            for (auto const& transition : layer.transitions) {
+                if (!transition.id.empty() && !seenIds.insert(transition.id).second) {
+                    report(layer.id, transition.id, fmt::format("duplicate transition id '{}'", transition.id));
+                }
+                ValidateTransitionTarget(graph, layer, transition, report);
+            }
+        }
+    }
+
+    std::vector<GraphValidationError> ValidateFlowGraph(FlowGraph const& graph) {
+        std::vector<GraphValidationError> errors;
+        ErrorReporter report = [&errors](std::string layerId, std::string transitionId, std::string message) {
+            errors.push_back({ std::move(layerId), std::move(transitionId), std::move(message) });
+        };
+        ValidateLayerIdUniqueness(graph, report);
+        ValidateInitial(graph, report);
+        for (auto const& layer : graph.layers) {
+            ValidateLayerTransitions(graph, layer, report);
+        }
+        return errors;
+    }
+
+    LoadResult LoadFlowGraphFromJson(nlohmann::json const& root) {
+        LoadResult result;
+        if (!root.is_object()) {
+            result.errors.push_back({ "", "", "root JSON value must be an object" });
+            return result;
+        }
+
+        ParseContext ctx{ result.errors, "", "" };
+        FlowGraph graph;
+        graph.initial = root.value("initial", "");
+        if (graph.initial.empty()) {
+            ctx.Error("graph missing 'initial'");
+        }
+        if (root.contains("policy")) {
+            graph.policy = ParsePolicy(root.at("policy"), ctx);
+        }
+        if (root.contains("layers")) {
+            auto const& arr = root.at("layers");
+            if (!arr.is_array()) {
+                ctx.Error("'layers' must be an array");
+            } else {
+                for (auto const& item : arr) {
+                    graph.layers.push_back(ParseLayer(item, ctx));
+                }
+            }
+        } else {
+            ctx.Error("graph missing 'layers'");
+        }
+
+        auto structural = ValidateFlowGraph(graph);
+        result.errors.insert(result.errors.end(), structural.begin(), structural.end());
+        if (result.errors.empty()) {
+            result.graph = std::move(graph);
+        }
+        return result;
+    }
+
+    LoadResult LoadFlowGraphFromFile(std::filesystem::path const& path) {
+        LoadResult result;
+        std::ifstream in(path);
+        if (!in) {
+            result.errors.push_back({ "", "", fmt::format("could not open flow graph file '{}'", path.string()) });
+            return result;
+        }
+        nlohmann::json root;
+        try {
+            in >> root;
+        } catch (nlohmann::json::parse_error const& e) {
+            result.errors.push_back({ "", "", fmt::format("JSON parse error in '{}': {}", path.string(), e.what()) });
+            return result;
+        }
+        return LoadFlowGraphFromJson(root);
+    }
+}

--- a/src/flow/transitioning_layer.cpp
+++ b/src/flow/transitioning_layer.cpp
@@ -36,10 +36,22 @@ namespace moth_ui::flow {
     }
 
     bool TransitioningLayer::OnEvent(Event const& event) {
-        if (m_active && m_uiRoot) {
-            return m_uiRoot->Broadcast(event);
+        if (!m_active || !m_uiRoot) {
+            return false;
         }
-        return false;
+        // A captured node gets first crack at every event so widgets in an
+        // exclusive input mode (e.g. a text field being typed into) win over
+        // siblings that would otherwise consume the event during the normal
+        // broadcast walk. The capture-holder declines (returns false) for
+        // events it doesn't care about; we then fall through to the regular
+        // depth-first dispatch, which will revisit the capture-holder via the
+        // tree walk. Implementors must handle that second visit idempotently.
+        if (auto captured = m_uiRoot->GetCapturedNode()) {
+            if (captured->OnEvent(event)) {
+                return true;
+            }
+        }
+        return m_uiRoot->Broadcast(event);
     }
 
     void TransitioningLayer::Update(uint32_t ticks) {

--- a/src/flow/transitioning_layer.cpp
+++ b/src/flow/transitioning_layer.cpp
@@ -1,0 +1,92 @@
+#include "common.h"
+#include "moth_ui/flow/transitioning_layer.h"
+
+#include "moth_ui/context.h"
+#include "moth_ui/events/event_dispatch.h"
+#include "moth_ui/layers/layer_stack.h"
+#include "moth_ui/node_factory.h"
+#include "moth_ui/nodes/group.h"
+#include "moth_ui/utils/rect.h"
+
+namespace moth_ui::flow {
+
+    TransitioningLayer::TransitioningLayer(Context& context, std::string_view layoutPath)
+        : m_context(context) {
+        if (!layoutPath.empty()) {
+            auto [node, result] = NodeFactory::Get().Create(
+                m_context, std::filesystem::path(layoutPath), GetWidth(), GetHeight());
+            m_uiRoot = node;
+        }
+        if (m_uiRoot) {
+            m_uiRoot->SetEventHandler([this](Node* /*node*/, Event const& event) {
+                EventDispatch dispatch(event);
+                dispatch.Dispatch(this, &TransitioningLayer::OnAnimationStopped);
+                return dispatch.GetHandled();
+            });
+        }
+    }
+
+    TransitioningLayer::~TransitioningLayer() = default;
+
+    void TransitioningLayer::OnAddedToStack(LayerStack* stack) {
+        Layer::OnAddedToStack(stack);
+        if (m_uiRoot) {
+            m_uiRoot->SetScreenRect({ { 0, 0 }, { GetWidth(), GetHeight() } });
+        }
+    }
+
+    bool TransitioningLayer::OnEvent(Event const& event) {
+        if (m_active && m_uiRoot) {
+            return m_uiRoot->Broadcast(event);
+        }
+        return false;
+    }
+
+    void TransitioningLayer::Update(uint32_t ticks) {
+        if (m_uiRoot) {
+            m_uiRoot->Update(ticks);
+        }
+    }
+
+    void TransitioningLayer::Draw() {
+        if (m_uiRoot) {
+            m_uiRoot->Draw();
+        }
+    }
+
+    void TransitioningLayer::OnEnter() {
+        m_active = true;
+    }
+
+    void TransitioningLayer::OnExit() {
+        m_active = false;
+    }
+
+    void TransitioningLayer::TransitionIn(std::string_view tag, std::function<void()> done) {
+        PlayClip(tag, std::move(done));
+    }
+
+    void TransitioningLayer::TransitionOut(std::string_view tag, std::function<void()> done) {
+        PlayClip(tag, std::move(done));
+    }
+
+    void TransitioningLayer::PlayClip(std::string_view tag, std::function<void()> done) {
+        if (!m_uiRoot || tag.empty() || !m_uiRoot->HasAnimation(tag)) {
+            done();
+            return;
+        }
+        m_pendingClipName = std::string(tag);
+        m_pendingDone = std::move(done);
+        m_uiRoot->SetAnimation(tag);
+    }
+
+    bool TransitioningLayer::OnAnimationStopped(EventAnimationStopped const& event) {
+        if (m_pendingDone && event.GetClipName() == m_pendingClipName) {
+            auto done = std::move(m_pendingDone);
+            m_pendingClipName.clear();
+            done();
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/layers/layer_stack.cpp
+++ b/src/layers/layer_stack.cpp
@@ -42,6 +42,19 @@ namespace moth_ui {
         }
     }
 
+    std::unique_ptr<Layer> LayerStack::DetachLayer(Layer* layer) {
+        auto it = std::find_if(std::begin(m_layers), std::end(m_layers), [layer](auto& candidate) {
+            return candidate.get() == layer;
+        });
+        if (std::end(m_layers) == it) {
+            return nullptr;
+        }
+        auto owned = std::move(*it);
+        m_layers.erase(it);
+        owned->OnRemovedFromStack();
+        return owned;
+    }
+
     bool LayerStack::OnEvent(Event const& event) {
         // Walk top-to-bottom. A modal layer terminates dispatch regardless of
         // whether it consumed the event, so layers beneath it remain isolated.

--- a/src/layers/layer_stack.cpp
+++ b/src/layers/layer_stack.cpp
@@ -43,17 +43,32 @@ namespace moth_ui {
     }
 
     bool LayerStack::OnEvent(Event const& event) {
+        // Walk top-to-bottom. A modal layer terminates dispatch regardless of
+        // whether it consumed the event, so layers beneath it remain isolated.
         for (auto it = m_layers.rbegin(); it != m_layers.rend(); ++it) {
-            if ((*it)->OnEvent(event)) {
+            bool const handled = (*it)->OnEvent(event);
+            if (handled) {
                 return true;
+            }
+            if ((*it)->IsModal()) {
+                return false;
             }
         }
         return false;
     }
 
     void LayerStack::Update(uint32_t ticks) {
-        for (auto&& layer : m_layers) {
-            layer->Update(ticks);
+        // Update layers from the topmost modal upward. Anything beneath a
+        // modal layer is suspended (no Update call) until the modal is popped.
+        auto begin = m_layers.begin();
+        for (auto it = m_layers.rbegin(); it != m_layers.rend(); ++it) {
+            if ((*it)->IsModal()) {
+                begin = it.base() - 1;
+                break;
+            }
+        }
+        for (auto it = begin; it != m_layers.end(); ++it) {
+            (*it)->Update(ticks);
         }
     }
 

--- a/src/layout/layout_entity_ref.cpp
+++ b/src/layout/layout_entity_ref.cpp
@@ -97,6 +97,21 @@ namespace moth_ui {
         return success;
     }
 
+    // TODO: currently unreachable. The only caller (Node::ReloadEntity) was
+    // removed because this function reverted user edits by stamping the stale
+    // m_childOverrides JSON over a freshly-edited child entity. Overrides are
+    // already baked into child entities at Deserialize time (see the loop in
+    // Deserialize that calls child->DeserializeOverrides), and nothing in the
+    // ReloadEntity path resets a child entity to base values, so there is
+    // nothing to reapply during a normal reload.
+    //
+    // Keep this (and m_childOverrides, Group::ReapplyOverrides) until we
+    // confirm no future feature needs it. The likely future caller is
+    // hot-reload of the referenced sub-layout: re-running CopyLayout from a
+    // freshly loaded Layout would reset child entities to base values, after
+    // which overrides would need to be reapplied. If we add that, drive the
+    // reapply off the entity's current diff vs m_hardReference rather than the
+    // stale on-disk JSON snapshot stored here.
     void LayoutEntityRef::ReapplyOverrides(LayoutEntity& entity) const {
         for (int i = 0; i < static_cast<int>(m_children.size()); ++i) {
             if (m_children[i].get() == &entity) {

--- a/src/nodes/group.cpp
+++ b/src/nodes/group.cpp
@@ -154,7 +154,12 @@ namespace moth_ui {
 
     std::shared_ptr<Node> Group::FindChild(std::string_view id) {
         if (id == m_id) {
-            return shared_from_this();
+            // weak_from_this() is empty during construction, so shared_from_this()
+            // would throw bad_weak_ptr if a widget ctor calls FindChild for its
+            // own id. Fall through to the child search in that case.
+            if (auto self = weak_from_this().lock()) {
+                return self;
+            }
         }
         std::shared_ptr<Node> found;
         for (auto&& child : m_children) {

--- a/src/nodes/group.cpp
+++ b/src/nodes/group.cpp
@@ -91,6 +91,14 @@ namespace moth_ui {
         m_children.insert(std::next(std::begin(m_children), toIndex), std::move(child));
     }
 
+    void Group::SetCapturedNode(std::shared_ptr<Node> node) {
+        m_capturedNode = node;
+    }
+
+    std::shared_ptr<Node> Group::GetCapturedNode() const {
+        return m_capturedNode.lock();
+    }
+
     bool Group::HasAnimation(std::string_view name) const {
         if (m_layout) {
             auto& animationClips = m_typedLayout->m_clips;

--- a/src/nodes/group.cpp
+++ b/src/nodes/group.cpp
@@ -189,6 +189,9 @@ namespace moth_ui {
         m_animationClipController = std::make_unique<AnimationClipController>(this);
     }
 
+    // TODO: currently unreachable — see LayoutEntityRef::ReapplyOverrides for why
+    // the Node::ReloadEntity call site was removed and the conditions under
+    // which a future caller would need it.
     void Group::ReapplyOverrides(LayoutEntity& childLayout) {
         if (auto* ref = dynamic_cast<LayoutEntityRef*>(m_layout.get())) {
             ref->ReapplyOverrides(childLayout);

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -34,6 +34,48 @@ namespace moth_ui {
         return OnEvent(event);
     }
 
+    namespace {
+        Group* FindRootGroup(Node* node) {
+            if (node == nullptr) {
+                return nullptr;
+            }
+            Group* parent = node->GetParent();
+            if (parent == nullptr) {
+                // A detached node has no root; capture has nowhere to live.
+                return nullptr;
+            }
+            while (parent->GetParent() != nullptr) {
+                parent = parent->GetParent();
+            }
+            return parent;
+        }
+    }
+
+    void Node::RequestInputCapture() {
+        if (auto* root = FindRootGroup(this)) {
+            root->SetCapturedNode(shared_from_this());
+        }
+    }
+
+    void Node::ReleaseInputCapture() {
+        if (auto* root = FindRootGroup(this)) {
+            if (root->GetCapturedNode().get() == this) {
+                root->SetCapturedNode(nullptr);
+            }
+        }
+    }
+
+    bool Node::HasInputCapture() const {
+        Group const* parent = GetParent();
+        if (parent == nullptr) {
+            return false;
+        }
+        while (parent->GetParent() != nullptr) {
+            parent = parent->GetParent();
+        }
+        return parent->GetCapturedNode().get() == this;
+    }
+
     bool Node::OnEvent(Event const& event) {
         if (m_eventHandler) {
             return m_eventHandler(this, event);

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -194,7 +194,10 @@ namespace moth_ui {
 
     std::shared_ptr<Node> Node::FindChild(std::string_view id) {
         if (id == m_id) {
-            return shared_from_this();
+            // weak_from_this() is empty during construction, so shared_from_this()
+            // would throw bad_weak_ptr if a widget ctor calls FindChild for its
+            // own id. Return nullptr in that case rather than aborting.
+            return weak_from_this().lock();
         }
         return nullptr;
     }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -174,7 +174,13 @@ namespace moth_ui {
         ReloadEntityInternal();
 
         if (m_parent != nullptr) {
-            m_parent->ReapplyOverrides(*m_layout);
+            // TODO: previously also called m_parent->ReapplyOverrides(*m_layout)
+            // here. Removed because it stamped stale on-disk override JSON over a
+            // freshly-edited entity, reverting edits before save. The reapply is
+            // unnecessary in current code: overrides are baked into child entities
+            // at Deserialize time and nothing in the ReloadEntity path resets them.
+            // See LayoutEntityRef::ReapplyOverrides for the conditions under which
+            // such a call would actually be needed.
             m_visible = m_layout->m_visible;
             m_blend = m_layout->m_blend;
         }

--- a/src/widgets/ui_button.cpp
+++ b/src/widgets/ui_button.cpp
@@ -33,12 +33,13 @@ namespace moth_ui {
     }
 
     bool UIButton::OnMouseUp(EventMouseUp const& event) {
-        if (IsInBounds(event.GetPosition()) && m_state == State::Pressed) {
+        bool const activated = IsInBounds(event.GetPosition()) && m_state == State::Pressed;
+        if (activated) {
             SetState(State::Activated);
         } else {
             SetState(State::Idle);
         }
-        return false;
+        return activated;
     }
 
     bool UIButton::OnMouseMove(EventMouseMove const& event) {

--- a/src/widgets/ui_button.cpp
+++ b/src/widgets/ui_button.cpp
@@ -1,0 +1,81 @@
+#include "common.h"
+#include "moth_ui/widgets/ui_button.h"
+
+#include "moth_ui/events/event_dispatch.h"
+
+namespace moth_ui {
+    UIButton::UIButton(Context& context, std::shared_ptr<LayoutEntityGroup> entity)
+        : Widget<UIButton>(context, std::move(entity)) {
+    }
+
+    void UIButton::Update(uint32_t ticks) {
+        Group::Update(ticks);
+    }
+
+    bool UIButton::OnEvent(Event const& event) {
+        EventDispatch dispatch(event);
+        dispatch.Dispatch(this, &UIButton::OnMouseDown);
+        dispatch.Dispatch(this, &UIButton::OnMouseUp);
+        dispatch.Dispatch(this, &UIButton::OnMouseMove);
+        return dispatch.GetHandled() || Group::OnEvent(event);
+    }
+
+    void UIButton::SetClickAction(std::function<void()> action) {
+        m_clickAction = std::move(action);
+    }
+
+    bool UIButton::OnMouseDown(EventMouseDown const& event) {
+        if (IsInBounds(event.GetPosition())) {
+            SetState(State::Pressed);
+            return true;
+        }
+        return false;
+    }
+
+    bool UIButton::OnMouseUp(EventMouseUp const& event) {
+        if (IsInBounds(event.GetPosition()) && m_state == State::Pressed) {
+            SetState(State::Activated);
+        } else {
+            SetState(State::Idle);
+        }
+        return false;
+    }
+
+    bool UIButton::OnMouseMove(EventMouseMove const& event) {
+        if (IsInBounds(event.GetPosition())) {
+            if (m_state != State::Pressed) {
+                SetState(State::Hovered);
+            }
+        } else {
+            if (m_state == State::Hovered) {
+                SetState(State::Idle);
+            }
+        }
+        return false;
+    }
+
+    void UIButton::SetState(State state) {
+        if (m_state == state) {
+            return;
+        }
+        m_state = state;
+        switch (m_state) {
+        default:
+        case State::Idle:
+            SetAnimation("idle");
+            break;
+        case State::Hovered:
+            SetAnimation("hover");
+            break;
+        case State::Pressed:
+            SetAnimation("press");
+            break;
+        case State::Activated:
+            SetAnimation("activate");
+            if (m_clickAction) {
+                m_clickAction();
+            }
+            break;
+        }
+    }
+}

--- a/src/widgets/ui_scroll_view.cpp
+++ b/src/widgets/ui_scroll_view.cpp
@@ -1,0 +1,98 @@
+#include "common.h"
+#include "moth_ui/widgets/ui_scroll_view.h"
+
+#include "moth_ui/context.h"
+#include "moth_ui/events/event_mouse.h"
+#include "moth_ui/graphics/irenderer.h"
+
+#include <algorithm>
+#include <optional>
+
+namespace moth_ui {
+    namespace {
+        // Returns the pointer position for the positional mouse events, or
+        // nullopt for any other event type.
+        std::optional<IntVec2> PositionOf(Event const& event) {
+            if (auto const* e = event_cast<EventMouseDown>(event)) {
+                return e->GetPosition();
+            }
+            if (auto const* e = event_cast<EventMouseUp>(event)) {
+                return e->GetPosition();
+            }
+            if (auto const* e = event_cast<EventMouseMove>(event)) {
+                return e->GetPosition();
+            }
+            return std::nullopt;
+        }
+    }
+
+    UIScrollView::UIScrollView(Context& context, std::shared_ptr<LayoutEntityGroup> entity)
+        : Widget<UIScrollView>(context, std::move(entity)) {
+    }
+
+    void UIScrollView::SetContent(std::shared_ptr<Node> content) {
+        if (m_content) {
+            RemoveChild(m_content);
+        }
+        m_content = std::move(content);
+        m_scrollY = 0.0f;
+        if (m_content) {
+            AddChild(m_content);
+            auto const& offset = m_content->GetLayoutRect().offset;
+            m_baseOffsetTop = offset.topLeft.y;
+            m_baseOffsetBottom = offset.bottomRight.y;
+            m_content->RecalculateBounds();
+        }
+    }
+
+    bool UIScrollView::Broadcast(Event const& event) {
+        // Scroll when the wheel turns over this viewport, and consume the event
+        // so it doesn't reach another scroller or the layer behind us. The wheel
+        // event carries the current cursor position, so this works even on the
+        // first scroll after the view appears under a stationary pointer, with
+        // no prior move event to seed it.
+        if (auto const* wheel = event_cast<EventMouseWheel>(event)) {
+            if (IsInBounds(wheel->GetPosition())) {
+                ApplyScroll(static_cast<float>(-wheel->GetDelta().y) * m_scrollStep);
+                return true;
+            }
+            return false;
+        }
+
+        // Drop pointer events outside the viewport before they descend into the
+        // content, so rows scrolled out of sight can't be hovered or clicked.
+        if (auto const position = PositionOf(event)) {
+            if (!IsInBounds(*position)) {
+                return false;
+            }
+        }
+
+        return Group::Broadcast(event);
+    }
+
+    void UIScrollView::DrawInternal() {
+        m_context.GetRenderer().PushClip(GetScreenRect());
+        Group::DrawInternal();
+        m_context.GetRenderer().PopClip();
+    }
+
+    void UIScrollView::ApplyScroll(float deltaY) {
+        if (!m_content) {
+            return;
+        }
+        m_scrollY = std::clamp(m_scrollY + deltaY, 0.0f, MaxScroll());
+        auto& offset = m_content->GetLayoutRect().offset;
+        offset.topLeft.y = m_baseOffsetTop - m_scrollY;
+        offset.bottomRight.y = m_baseOffsetBottom - m_scrollY;
+        m_content->RecalculateBounds();
+    }
+
+    float UIScrollView::MaxScroll() const {
+        if (!m_content) {
+            return 0.0f;
+        }
+        float const contentH = static_cast<float>(m_content->GetScreenRect().h());
+        float const viewportH = static_cast<float>(GetScreenRect().h());
+        return std::max(0.0f, contentH - viewportH);
+    }
+}

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -2,6 +2,7 @@
 #include "moth_ui/widgets/widget.h"
 
 #include "moth_ui/widgets/ui_button.h"
+#include "moth_ui/widgets/ui_scroll_view.h"
 
 namespace moth_ui {
     void EnsureWidgetsRegistered() {
@@ -10,5 +11,6 @@ namespace moth_ui {
         // their SelfRegister() initialisers intact. Add a new line for each
         // bundled widget added to moth_ui.
         (void)Widget<UIButton>::s_widgetIsRegistered_;
+        (void)Widget<UIScrollView>::s_widgetIsRegistered_;
     }
 }

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+#include "moth_ui/widgets/widget.h"
+
+#include "moth_ui/widgets/ui_button.h"
+
+namespace moth_ui {
+    void EnsureWidgetsRegistered() {
+        // Touching each widget's template static here forces the linker to
+        // retain this TU along with every referenced widget's TU, keeping
+        // their SelfRegister() initialisers intact. Add a new line for each
+        // bundled widget added to moth_ui.
+        (void)Widget<UIButton>::s_widgetIsRegistered_;
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,8 @@ set(SOURCES
     src/test_node_factory.cpp
     src/test_layout_cache.cpp
     src/test_layer_stack.cpp
+    src/test_flow_graph.cpp
+    src/test_flow.cpp
     # API surface tests — compile-time only, no runtime assertions
     src/api_surface_umbrella.cpp
     src/api_surface_fwd.cpp

--- a/tests/src/api_surface_events.cpp
+++ b/tests/src/api_surface_events.cpp
@@ -48,9 +48,10 @@ TEST_CASE("Mouse event method signatures are stable", "[api][events][mouse]") {
     FloatVec2 const& (EventMouseMove::*moveDelta)() const = &EventMouseMove::GetDelta;
 
     IntVec2 const& (EventMouseWheel::*wheelDelta)() const = &EventMouseWheel::GetDelta;
+    IntVec2 const& (EventMouseWheel::*wheelPos)()   const = &EventMouseWheel::GetPosition;
 
     (void)downBtn; (void)downPos; (void)upBtn; (void)upPos;
-    (void)movePos; (void)moveDelta; (void)wheelDelta;
+    (void)movePos; (void)moveDelta; (void)wheelDelta; (void)wheelPos;
     SUCCEED();
 }
 

--- a/tests/src/test_event_dispatch.cpp
+++ b/tests/src/test_event_dispatch.cpp
@@ -56,10 +56,12 @@ TEST_CASE("EventMouseMove stores position and delta", "[event][mouse]") {
     REQUIRE(ev.GetDelta().y == Catch::Approx(-2.0f));
 }
 
-TEST_CASE("EventMouseWheel stores delta", "[event][mouse]") {
-    EventMouseWheel ev(IntVec2{ 0, 3 });
+TEST_CASE("EventMouseWheel stores delta and position", "[event][mouse]") {
+    EventMouseWheel ev(IntVec2{ 0, 3 }, IntVec2{ 12, 34 });
     REQUIRE(ev.GetType() == EVENTTYPE_MOUSE_WHEEL);
     REQUIRE(ev.GetDelta().y == 3);
+    REQUIRE(ev.GetPosition().x == 12);
+    REQUIRE(ev.GetPosition().y == 34);
 }
 
 TEST_CASE("Event Clone produces independent copy", "[event][clone]") {

--- a/tests/src/test_flow.cpp
+++ b/tests/src/test_flow.cpp
@@ -638,3 +638,70 @@ TEST_CASE("Passthrough overlay does not set the modal flag", "[flow]") {
 
     REQUIRE_FALSE(f.created["overlay"]->IsModal());
 }
+
+TEST_CASE("Cached layer survives a Pop and is reused on re-push", "[flow][cached]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "shell";
+
+    auto shell = MakeMockSpec("shell");
+    shell.transitions.push_back(MakeTransition("open", "tray", TransitionKind::Push, EventTrigger("open")));
+    g.layers.push_back(shell);
+
+    auto tray = MakeMockSpec("tray", LayerKind::Overlay);
+    tray.construction = Construction::Cached;
+    tray.transitions.push_back(MakeTransition("close", std::string(kBackTarget), TransitionKind::Pop, EventTrigger("close")));
+    g.layers.push_back(tray);
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+
+    flow->Trigger("shell.open");
+    flow->Tick(0);
+    MockParticipantLayer* first = f.created["tray"];
+    REQUIRE(first != nullptr);
+
+    flow->Trigger("tray.close");
+    flow->Tick(0);
+    // first is still alive — Pop should have detached, not destroyed, the cached layer.
+
+    // Forget the create-time pointer so we can prove the next push reuses
+    // the same instance rather than constructing a new one. Our factory
+    // would overwrite f.created["tray"] if it were called again.
+    f.created.erase("tray");
+
+    flow->Trigger("shell.open");
+    flow->Tick(0);
+    // Factory was NOT invoked a second time; the cached instance came back.
+    REQUIRE(f.created.count("tray") == 0);
+}
+
+TEST_CASE("Fresh layer is rebuilt each push", "[flow]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "shell";
+
+    auto shell = MakeMockSpec("shell");
+    shell.transitions.push_back(MakeTransition("open", "tray", TransitionKind::Push, EventTrigger("open")));
+    g.layers.push_back(shell);
+
+    auto tray = MakeMockSpec("tray", LayerKind::Overlay);
+    tray.construction = Construction::Fresh;
+    tray.transitions.push_back(MakeTransition("close", std::string(kBackTarget), TransitionKind::Pop, EventTrigger("close")));
+    g.layers.push_back(tray);
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+
+    flow->Trigger("shell.open");
+    flow->Tick(0);
+    flow->Trigger("tray.close");
+    flow->Tick(0);
+
+    f.created.erase("tray");
+
+    flow->Trigger("shell.open");
+    flow->Tick(0);
+    // Factory WAS invoked again — fresh instance.
+    REQUIRE(f.created.count("tray") == 1);
+}

--- a/tests/src/test_flow.cpp
+++ b/tests/src/test_flow.cpp
@@ -344,13 +344,16 @@ TEST_CASE("Action hooks fire in OnStart / OnMidpoint / OnComplete order", "[flow
     flow->Trigger("title.play");
     flow->Tick(0);
 
+    // OnExit fires in BeginTransition (before OnStart actions); OnEnter fires
+    // in DoStackMutation (before OnMidpoint actions). The hook-internal order
+    // (start1 < start2 < mid < complete) is what the test name guarantees.
     REQUIRE(f.log == std::vector<std::string>{
+        "title.OnExit",
         "action:start1",
         "action:start2",
-        "title.OnExit",
         "title.Out:transition_out",
-        "action:mid",
         "game.OnEnter",
+        "action:mid",
         "game.In:transition_in",
         "action:complete",
     });
@@ -457,6 +460,12 @@ TEST_CASE("Re-entry policy: Reject drops new triggers mid-transition", "[flow][r
     f.log.clear();
 
     flow->Trigger("a.go");
+    // Pump into OutAnimating so a's TransitionOut runs and captures the
+    // pendingDone callback. Without this Tick the second Trigger lands while
+    // the machine is still in OnStart, no async call has been made yet, and
+    // pendingDone is still empty — moving from an empty std::function and
+    // invoking it is platform-dependent UB (throws on MSVC's STL).
+    flow->Tick(0);
     flow->Trigger("a.go");  // dropped: transition already in flight
     auto done = std::move(f.created["a"]->pendingDone);
     done();

--- a/tests/src/test_flow.cpp
+++ b/tests/src/test_flow.cpp
@@ -1,0 +1,640 @@
+#include "mock_context.h"
+#include "moth_ui/events/event_key.h"
+#include "moth_ui/flow/flow.h"
+#include "moth_ui/flow/flow_graph.h"
+#include "moth_ui/flow/transition_participant.h"
+#include "moth_ui/layers/layer.h"
+#include "moth_ui/layers/layer_stack.h"
+
+#include <catch2/catch_all.hpp>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace moth_ui;
+using namespace moth_ui::flow;
+
+namespace {
+    // A test layer that records every lifecycle call and can either complete
+    // its transitions synchronously (autoComplete=true) or hold the done
+    // callback for the test to fire later.
+    class MockParticipantLayer : public Layer, public ITransitionParticipant {
+    public:
+        std::vector<std::string>* log = nullptr;
+        std::string name;
+        bool autoComplete = true;
+        std::function<void()> pendingDone;
+
+        MockParticipantLayer() = default;
+        MockParticipantLayer(MockParticipantLayer const&) = delete;
+        MockParticipantLayer(MockParticipantLayer&&) = delete;
+        MockParticipantLayer& operator=(MockParticipantLayer const&) = delete;
+        MockParticipantLayer& operator=(MockParticipantLayer&&) = delete;
+        ~MockParticipantLayer() override = default;
+
+        void OnEnter() override { Record("OnEnter"); }
+        void OnExit() override { Record("OnExit"); }
+
+        void TransitionIn(std::string_view tag, std::function<void()> done) override {
+            Record("In:" + std::string(tag));
+            if (autoComplete) {
+                done();
+            } else {
+                pendingDone = std::move(done);
+            }
+        }
+
+        void TransitionOut(std::string_view tag, std::function<void()> done) override {
+            Record("Out:" + std::string(tag));
+            if (autoComplete) {
+                done();
+            } else {
+                pendingDone = std::move(done);
+            }
+        }
+
+    private:
+        void Record(std::string event) const {
+            if (log != nullptr) {
+                log->push_back(name + "." + std::move(event));
+            }
+        }
+    };
+
+    struct FlowFixture {
+        MockContext mock;
+        LayerStack stack{ mock.renderer, IntVec2{800, 600}, IntVec2{800, 600} };
+        std::vector<std::string> log;
+        std::unordered_map<std::string, MockParticipantLayer*> created;
+
+        Flow::LayerFactory MakeFactory() {
+            return [this](Context&, LayerSpec const& spec) -> std::unique_ptr<Layer> {
+                auto layer = std::make_unique<MockParticipantLayer>();
+                layer->name = spec.id;
+                layer->log = &log;
+                created[spec.id] = layer.get();
+                return layer;
+            };
+        }
+
+        std::unique_ptr<Flow> MakeFlow(FlowGraph graph) {
+            auto f = std::make_unique<Flow>(stack, mock.context, std::move(graph));
+            // Use our mock factory as the default route for *every* layer:
+            // give each LayerSpec a factory name and register that name.
+            f->RegisterFactory("mock", MakeFactory());
+            return f;
+        }
+    };
+
+    // Helper: build a graph where every layer is built by the "mock" factory.
+    LayerSpec MakeMockSpec(std::string id, LayerKind kind = LayerKind::Screen) {
+        LayerSpec spec;
+        spec.id = std::move(id);
+        spec.factory = "mock";
+        spec.kind = kind;
+        return spec;
+    }
+
+    TransitionSpec MakeTransition(std::string id, std::string to, TransitionKind kind, TriggerSpec trigger) {
+        TransitionSpec t;
+        t.id = std::move(id);
+        t.to = std::move(to);
+        t.kind = kind;
+        t.trigger = std::move(trigger);
+        return t;
+    }
+
+    TriggerSpec EventTrigger(std::string name) {
+        return TriggerSpec{ TriggerKind::Event, std::move(name), Key::Unknown, 0 };
+    }
+
+    TriggerSpec KeyTrigger(Key key) {
+        return TriggerSpec{ TriggerKind::Key, {}, key, 0 };
+    }
+}
+
+TEST_CASE("Flow::Start pushes the initial layer and runs OnEnter + TransitionIn", "[flow]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "title";
+    g.layers.push_back(MakeMockSpec("title"));
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+
+    REQUIRE(f.created.count("title") == 1);
+    REQUIRE(f.log == std::vector<std::string>{ "title.OnEnter", "title.In:transition_in" });
+}
+
+TEST_CASE("Flow::Start is idempotent", "[flow]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "title";
+    g.layers.push_back(MakeMockSpec("title"));
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    flow->Start();  // second call must be a no-op
+
+    REQUIRE(f.log == std::vector<std::string>{ "title.OnEnter", "title.In:transition_in" });
+}
+
+TEST_CASE("Push transition: source OnExit, target OnEnter, modal flag set", "[flow]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "game";
+
+    auto game = MakeMockSpec("game");
+    game.transitions.push_back(MakeTransition("open", "pause", TransitionKind::Push, EventTrigger("open")));
+    g.layers.push_back(game);
+
+    auto pause = MakeMockSpec("pause", LayerKind::Overlay);
+    pause.modality = Modality::Modal;
+    g.layers.push_back(pause);
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    f.log.clear();
+
+    flow->Trigger("game.open");
+    flow->Tick(0);
+
+    REQUIRE(f.log == std::vector<std::string>{
+        "game.OnExit",
+        "pause.OnEnter",
+        "pause.In:transition_in",
+    });
+    REQUIRE(f.created["pause"]->IsModal());
+    REQUIRE_FALSE(f.created["game"]->IsModal());
+}
+
+TEST_CASE("Push skips OutAnimating: source TransitionOut never fires", "[flow]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "game";
+
+    auto game = MakeMockSpec("game");
+    game.transitions.push_back(MakeTransition("open", "pause", TransitionKind::Push, EventTrigger("open")));
+    g.layers.push_back(game);
+
+    auto pause = MakeMockSpec("pause", LayerKind::Overlay);
+    g.layers.push_back(pause);
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    f.log.clear();
+
+    flow->Trigger("game.open");
+    flow->Tick(0);
+
+    for (auto const& entry : f.log) {
+        REQUIRE_FALSE(entry.find("game.Out:") == 0);
+    }
+}
+
+TEST_CASE("Pop transition: overlay OnExit + transition_out, revealed layer OnEnter", "[flow]") {
+    // Regression: OnEnter was previously not called on the layer revealed by a
+    // Pop, so the revealed layer's TransitioningLayer.m_active stayed false
+    // and input/events stopped reaching it after a pause→resume cycle.
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "game";
+
+    auto game = MakeMockSpec("game");
+    game.transitions.push_back(MakeTransition("open", "pause", TransitionKind::Push, EventTrigger("open")));
+    g.layers.push_back(game);
+
+    auto pause = MakeMockSpec("pause", LayerKind::Overlay);
+    pause.modality = Modality::Modal;
+    pause.transitions.push_back(MakeTransition("close", std::string(kBackTarget), TransitionKind::Pop, EventTrigger("close")));
+    g.layers.push_back(pause);
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    flow->Trigger("game.open");
+    flow->Tick(0);
+    f.log.clear();
+
+    flow->Trigger("pause.close");
+    flow->Tick(0);
+
+    REQUIRE(f.log == std::vector<std::string>{
+        "pause.OnExit",
+        "pause.Out:transition_out",
+        "game.OnEnter",
+    });
+}
+
+TEST_CASE("Pop skips InAnimating: revealed layer's TransitionIn does not fire", "[flow]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "game";
+
+    auto game = MakeMockSpec("game");
+    game.transitions.push_back(MakeTransition("open", "pause", TransitionKind::Push, EventTrigger("open")));
+    g.layers.push_back(game);
+
+    auto pause = MakeMockSpec("pause", LayerKind::Overlay);
+    pause.transitions.push_back(MakeTransition("close", std::string(kBackTarget), TransitionKind::Pop, EventTrigger("close")));
+    g.layers.push_back(pause);
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    flow->Trigger("game.open");
+    flow->Tick(0);
+    f.log.clear();
+
+    flow->Trigger("pause.close");
+    flow->Tick(0);
+
+    for (auto const& entry : f.log) {
+        REQUIRE_FALSE(entry.find("game.In:") == 0);
+    }
+}
+
+TEST_CASE("Replace transition: source out, target in", "[flow]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "title";
+
+    auto title = MakeMockSpec("title");
+    title.transitions.push_back(MakeTransition("play", "game", TransitionKind::Replace, EventTrigger("play")));
+    g.layers.push_back(title);
+    g.layers.push_back(MakeMockSpec("game"));
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    f.log.clear();
+
+    flow->Trigger("title.play");
+    flow->Tick(0);
+
+    REQUIRE(f.log == std::vector<std::string>{
+        "title.OnExit",
+        "title.Out:transition_out",
+        "game.OnEnter",
+        "game.In:transition_in",
+    });
+}
+
+TEST_CASE("Custom transition clips override layer defaults", "[flow]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "title";
+
+    auto title = MakeMockSpec("title");
+    auto t = MakeTransition("play", "game", TransitionKind::Replace, EventTrigger("play"));
+    t.outClip = "fade_out";
+    t.inClip = "fade_in";
+    title.transitions.push_back(t);
+    g.layers.push_back(title);
+    g.layers.push_back(MakeMockSpec("game"));
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    f.log.clear();
+
+    flow->Trigger("title.play");
+    flow->Tick(0);
+
+    bool foundOut = false;
+    bool foundIn = false;
+    for (auto const& entry : f.log) {
+        if (entry == "title.Out:fade_out") { foundOut = true; }
+        if (entry == "game.In:fade_in") { foundIn = true; }
+    }
+    REQUIRE(foundOut);
+    REQUIRE(foundIn);
+}
+
+TEST_CASE("Action hooks fire in OnStart / OnMidpoint / OnComplete order", "[flow][actions]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "title";
+
+    auto title = MakeMockSpec("title");
+    auto t = MakeTransition("play", "game", TransitionKind::Replace, EventTrigger("play"));
+    t.onStart = { "start1", "start2" };
+    t.onMidpoint = { "mid" };
+    t.onComplete = { "complete" };
+    title.transitions.push_back(t);
+    g.layers.push_back(title);
+    g.layers.push_back(MakeMockSpec("game"));
+
+    auto flow = f.MakeFlow(std::move(g));
+
+    auto registerLogged = [&](std::string name) {
+        flow->RegisterAction(name, [name, &f](std::function<void()> done) {
+            f.log.push_back("action:" + name);
+            done();
+        });
+    };
+    registerLogged("start1");
+    registerLogged("start2");
+    registerLogged("mid");
+    registerLogged("complete");
+
+    flow->Start();
+    f.log.clear();
+
+    flow->Trigger("title.play");
+    flow->Tick(0);
+
+    REQUIRE(f.log == std::vector<std::string>{
+        "action:start1",
+        "action:start2",
+        "title.OnExit",
+        "title.Out:transition_out",
+        "action:mid",
+        "game.OnEnter",
+        "game.In:transition_in",
+        "action:complete",
+    });
+}
+
+TEST_CASE("Unknown actions log and skip without breaking the transition", "[flow][actions]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "title";
+
+    auto title = MakeMockSpec("title");
+    auto t = MakeTransition("play", "game", TransitionKind::Replace, EventTrigger("play"));
+    t.onStart = { "missing_action" };
+    title.transitions.push_back(t);
+    g.layers.push_back(title);
+    g.layers.push_back(MakeMockSpec("game"));
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    f.log.clear();
+
+    flow->Trigger("title.play");
+    flow->Tick(0);
+
+    // The transition still completes end-to-end.
+    REQUIRE(f.log.back() == "game.In:transition_in");
+}
+
+TEST_CASE("Synchronous phases pump in a single Tick", "[flow][phases]") {
+    // Regression: previously each phase advanced one per Tick, leaving a
+    // visible idle frame between layer push and SetAnimation. The sync-phase
+    // pump in Tick collapses everything that can finish immediately into the
+    // same call.
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "game";
+
+    auto game = MakeMockSpec("game");
+    game.transitions.push_back(MakeTransition("open", "pause", TransitionKind::Push, EventTrigger("open")));
+    g.layers.push_back(game);
+    g.layers.push_back(MakeMockSpec("pause", LayerKind::Overlay));
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    f.log.clear();
+
+    flow->Trigger("game.open");
+    flow->Tick(0);  // ONE tick should reach In:transition_in
+
+    bool foundIn = false;
+    for (auto const& entry : f.log) {
+        if (entry == "pause.In:transition_in") { foundIn = true; }
+    }
+    REQUIRE(foundIn);
+}
+
+TEST_CASE("Async TransitionOut blocks phase advancement until done() fires", "[flow][async]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "title";
+
+    auto title = MakeMockSpec("title");
+    title.transitions.push_back(MakeTransition("play", "game", TransitionKind::Replace, EventTrigger("play")));
+    g.layers.push_back(title);
+    g.layers.push_back(MakeMockSpec("game"));
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    f.created["title"]->autoComplete = false;
+    f.log.clear();
+
+    flow->Trigger("title.play");
+    flow->Tick(0);
+    // Out:transition_out fired, then we wait for done().
+    REQUIRE(f.log.back() == "title.Out:transition_out");
+    REQUIRE(f.created.count("game") == 0);  // target not built yet
+
+    // Fire the pending done callback — phases now pump to completion.
+    auto done = std::move(f.created["title"]->pendingDone);
+    done();
+    flow->Tick(0);
+
+    REQUIRE(f.created.count("game") == 1);
+    REQUIRE(f.log.back() == "game.In:transition_in");
+}
+
+TEST_CASE("Re-entry policy: Reject drops new triggers mid-transition", "[flow][reentry]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "a";
+    g.policy.onReentry = ReentryPolicy::Reject;
+
+    auto a = MakeMockSpec("a");
+    a.transitions.push_back(MakeTransition("go", "b", TransitionKind::Replace, EventTrigger("go")));
+    g.layers.push_back(a);
+
+    auto b = MakeMockSpec("b");
+    b.transitions.push_back(MakeTransition("back", "a", TransitionKind::Replace, EventTrigger("back")));
+    g.layers.push_back(b);
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    f.created["a"]->autoComplete = false;
+    f.log.clear();
+
+    flow->Trigger("a.go");
+    flow->Trigger("a.go");  // dropped: transition already in flight
+    auto done = std::move(f.created["a"]->pendingDone);
+    done();
+    flow->Tick(0);
+
+    // Only one a→b cycle occurred.
+    REQUIRE(f.created.count("b") == 1);
+}
+
+TEST_CASE("Re-entry policy: Queue fires the held trigger when Idle", "[flow][reentry]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "a";
+    g.policy.onReentry = ReentryPolicy::Queue;
+
+    auto a = MakeMockSpec("a");
+    a.transitions.push_back(MakeTransition("go_b", "b", TransitionKind::Replace, EventTrigger("go_b")));
+    g.layers.push_back(a);
+
+    auto b = MakeMockSpec("b");
+    b.transitions.push_back(MakeTransition("go_c", "c", TransitionKind::Replace, EventTrigger("go_c")));
+    g.layers.push_back(b);
+    g.layers.push_back(MakeMockSpec("c"));
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    f.log.clear();
+
+    flow->Trigger("a.go_b");
+    flow->Trigger("b.go_c");  // queued — b doesn't exist yet but we tolerate the lookup miss; trigger by qualified id is resolved at Trigger() time
+    flow->Tick(0);
+
+    // a → b should complete; the b.go_c was queued mid-flight, then fired
+    // when the a→b cycle reached Idle, then b → c completed.
+    REQUIRE(f.created.count("c") == 1);
+}
+
+TEST_CASE("Trigger by unknown qualified id is a no-op", "[flow]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "a";
+    g.layers.push_back(MakeMockSpec("a"));
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    f.log.clear();
+
+    flow->Trigger("a.nonexistent");
+    flow->Trigger("nonexistent.x");
+    flow->Trigger("not_qualified");
+    flow->Tick(0);
+
+    REQUIRE(f.log.empty());
+}
+
+TEST_CASE("OnEvent dispatches key triggers from the topmost active layer", "[flow][input]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "game";
+
+    auto game = MakeMockSpec("game");
+    game.transitions.push_back(MakeTransition("pause", "pause_layer", TransitionKind::Push, KeyTrigger(Key::Escape)));
+    g.layers.push_back(game);
+    g.layers.push_back(MakeMockSpec("pause_layer", LayerKind::Overlay));
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    f.log.clear();
+
+    EventKey downEvent(KeyAction::Down, Key::Escape, 0);
+    bool const consumed = flow->OnEvent(downEvent);
+    flow->Tick(0);
+
+    REQUIRE(consumed);
+    REQUIRE(f.created.count("pause_layer") == 1);
+}
+
+TEST_CASE("OnEvent ignores keys that do not match any trigger", "[flow][input]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "game";
+    auto game = MakeMockSpec("game");
+    game.transitions.push_back(MakeTransition("pause", "pause_layer", TransitionKind::Push, KeyTrigger(Key::Escape)));
+    g.layers.push_back(game);
+    g.layers.push_back(MakeMockSpec("pause_layer", LayerKind::Overlay));
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+
+    EventKey downEvent(KeyAction::Down, Key::Space, 0);
+    bool const consumed = flow->OnEvent(downEvent);
+    REQUIRE_FALSE(consumed);
+    REQUIRE(f.created.count("pause_layer") == 0);
+}
+
+TEST_CASE("Emit routes a named event to the topmost active layer", "[flow][input]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "a";
+
+    auto a = MakeMockSpec("a");
+    a.transitions.push_back(MakeTransition("go", "b", TransitionKind::Replace, EventTrigger("a_event")));
+    g.layers.push_back(a);
+
+    auto b = MakeMockSpec("b");
+    b.transitions.push_back(MakeTransition("back", "a", TransitionKind::Replace, EventTrigger("b_event")));
+    g.layers.push_back(b);
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    f.log.clear();
+
+    // a is topmost; a_event matches a.go
+    flow->Emit("a_event");
+    flow->Tick(0);
+    REQUIRE(f.created.count("b") == 1);
+
+    // b_event won't match anything on a but does on b — b is now topmost
+    flow->Emit("b_event");
+    flow->Tick(0);
+    // a was rebuilt
+    REQUIRE(f.created.count("a") == 1);
+}
+
+TEST_CASE("Emit on unknown event name is a no-op", "[flow][input]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "a";
+    g.layers.push_back(MakeMockSpec("a"));
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    f.log.clear();
+    flow->Emit("nothing_matches_this");
+    flow->Tick(0);
+    REQUIRE(f.log.empty());
+}
+
+TEST_CASE("Modal flag is not set on Screen-kind targets", "[flow]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "title";
+
+    auto title = MakeMockSpec("title");
+    title.modality = Modality::Modal;  // ignored on screens
+    title.transitions.push_back(MakeTransition("play", "game", TransitionKind::Replace, EventTrigger("play")));
+    g.layers.push_back(title);
+
+    auto game = MakeMockSpec("game");
+    game.modality = Modality::Modal;  // ignored on screens
+    g.layers.push_back(game);
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    REQUIRE_FALSE(f.created["title"]->IsModal());
+
+    flow->Trigger("title.play");
+    flow->Tick(0);
+    REQUIRE_FALSE(f.created["game"]->IsModal());
+}
+
+TEST_CASE("Passthrough overlay does not set the modal flag", "[flow]") {
+    FlowFixture f;
+    FlowGraph g;
+    g.initial = "game";
+
+    auto game = MakeMockSpec("game");
+    game.transitions.push_back(MakeTransition("open", "overlay", TransitionKind::Push, EventTrigger("open")));
+    g.layers.push_back(game);
+
+    auto overlay = MakeMockSpec("overlay", LayerKind::Overlay);
+    overlay.modality = Modality::Passthrough;
+    g.layers.push_back(overlay);
+
+    auto flow = f.MakeFlow(std::move(g));
+    flow->Start();
+    flow->Trigger("game.open");
+    flow->Tick(0);
+
+    REQUIRE_FALSE(f.created["overlay"]->IsModal());
+}

--- a/tests/src/test_flow_graph.cpp
+++ b/tests/src/test_flow_graph.cpp
@@ -1,0 +1,415 @@
+#include "moth_ui/flow/flow_graph.h"
+
+#include <catch2/catch_all.hpp>
+#include <nlohmann/json.hpp>
+
+using namespace moth_ui;
+using namespace moth_ui::flow;
+using nlohmann::json;
+
+namespace {
+    json MinimalGraphJson() {
+        return json::parse(R"({
+            "initial": "a",
+            "layers": [
+                { "id": "a", "kind": "screen" }
+            ]
+        })");
+    }
+
+    LoadResult LoadOk(json const& j) {
+        auto result = LoadFlowGraphFromJson(j);
+        REQUIRE(result.ok());
+        return result;
+    }
+
+    bool HasError(LoadResult const& r, std::string const& fragment) {
+        for (auto const& e : r.errors) {
+            if (e.message.find(fragment) != std::string::npos) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+TEST_CASE("Loader rejects non-object root", "[flow_graph]") {
+    auto result = LoadFlowGraphFromJson(json::array());
+    REQUIRE_FALSE(result.ok());
+    REQUIRE(HasError(result, "root JSON value must be an object"));
+}
+
+TEST_CASE("Loader requires 'initial'", "[flow_graph]") {
+    auto j = MinimalGraphJson();
+    j.erase("initial");
+    auto result = LoadFlowGraphFromJson(j);
+    REQUIRE_FALSE(result.ok());
+    REQUIRE(HasError(result, "missing 'initial'"));
+}
+
+TEST_CASE("Loader requires 'layers'", "[flow_graph]") {
+    auto j = MinimalGraphJson();
+    j.erase("layers");
+    auto result = LoadFlowGraphFromJson(j);
+    REQUIRE_FALSE(result.ok());
+    REQUIRE(HasError(result, "missing 'layers'"));
+}
+
+TEST_CASE("Minimal graph parses cleanly", "[flow_graph]") {
+    auto result = LoadOk(MinimalGraphJson());
+    auto const& g = *result.graph;
+    REQUIRE(g.initial == "a");
+    REQUIRE(g.layers.size() == 1);
+    REQUIRE(g.layers[0].id == "a");
+    REQUIRE(g.layers[0].kind == LayerKind::Screen);
+    REQUIRE(g.layers[0].defaultInClip == "transition_in");
+    REQUIRE(g.layers[0].defaultOutClip == "transition_out");
+}
+
+TEST_CASE("Policy parses with defaults and overrides", "[flow_graph]") {
+    SECTION("defaults") {
+        auto result = LoadOk(MinimalGraphJson());
+        REQUIRE(result.graph->policy.onReentry == ReentryPolicy::Queue);
+        REQUIRE(result.graph->policy.actionTimeoutMs == kDefaultActionTimeoutMs);
+    }
+    SECTION("explicit values") {
+        constexpr int kOverrideTimeoutMs = 1000;
+        auto j = MinimalGraphJson();
+        j["policy"] = { { "onReentry", "reject" }, { "actionTimeoutMs", kOverrideTimeoutMs } };
+        auto result = LoadOk(j);
+        REQUIRE(result.graph->policy.onReentry == ReentryPolicy::Reject);
+        REQUIRE(result.graph->policy.actionTimeoutMs == kOverrideTimeoutMs);
+    }
+}
+
+TEST_CASE("LayerSpec parses optional fields", "[flow_graph]") {
+    auto j = json::parse(R"({
+        "initial": "game",
+        "layers": [
+            {
+                "id": "game",
+                "factory": "myFactory",
+                "layout": "assets/x.mothui",
+                "kind": "screen",
+                "construction": "cached",
+                "defaultInClip": "in_x",
+                "defaultOutClip": "out_x"
+            }
+        ]
+    })");
+    auto result = LoadOk(j);
+    auto const& layer = result.graph->layers[0];
+    REQUIRE(layer.factory.value() == "myFactory");
+    REQUIRE(layer.layout.value() == "assets/x.mothui");
+    REQUIRE(layer.construction == Construction::Cached);
+    REQUIRE(layer.defaultInClip == "in_x");
+    REQUIRE(layer.defaultOutClip == "out_x");
+}
+
+TEST_CASE("LayerSpec parses overlay modality", "[flow_graph]") {
+    auto j = json::parse(R"({
+        "initial": "a",
+        "layers": [
+            { "id": "a", "kind": "screen" },
+            { "id": "b", "kind": "overlay", "modality": "passthrough" }
+        ]
+    })");
+    auto result = LoadOk(j);
+    REQUIRE(result.graph->layers[1].kind == LayerKind::Overlay);
+    REQUIRE(result.graph->layers[1].modality == Modality::Passthrough);
+}
+
+TEST_CASE("Enum strings are case-insensitive", "[flow_graph]") {
+    auto j = json::parse(R"({
+        "initial": "a",
+        "layers": [
+            { "id": "a", "kind": "Screen", "construction": "FRESH" }
+        ]
+    })");
+    auto result = LoadOk(j);
+    REQUIRE(result.graph->layers[0].kind == LayerKind::Screen);
+    REQUIRE(result.graph->layers[0].construction == Construction::Fresh);
+}
+
+TEST_CASE("Unknown enum values are errors", "[flow_graph]") {
+    SECTION("layer kind") {
+        auto j = MinimalGraphJson();
+        j["layers"][0]["kind"] = "elephant";
+        auto result = LoadFlowGraphFromJson(j);
+        REQUIRE_FALSE(result.ok());
+        REQUIRE(HasError(result, "unknown kind"));
+    }
+    SECTION("modality") {
+        auto j = MinimalGraphJson();
+        j["layers"][0]["modality"] = "potato";
+        auto result = LoadFlowGraphFromJson(j);
+        REQUIRE_FALSE(result.ok());
+        REQUIRE(HasError(result, "unknown modality"));
+    }
+}
+
+TEST_CASE("Button trigger parses", "[flow_graph]") {
+    auto j = json::parse(R"({
+        "initial": "a",
+        "layers": [
+            { "id": "a", "kind": "screen", "transitions": [
+                { "id": "play", "to": "a", "kind": "replace",
+                  "trigger": { "type": "button", "id": "btn_play" } }
+            ]}
+        ]
+    })");
+    auto result = LoadOk(j);
+    auto const& t = result.graph->layers[0].transitions[0];
+    REQUIRE(t.trigger.kind == TriggerKind::Button);
+    REQUIRE(t.trigger.id == "btn_play");
+}
+
+TEST_CASE("Key trigger parses with named key", "[flow_graph]") {
+    auto j = json::parse(R"({
+        "initial": "a",
+        "layers": [
+            { "id": "a", "kind": "screen", "transitions": [
+                { "id": "pause", "to": "a", "kind": "replace",
+                  "trigger": { "type": "key", "key": "Escape" } }
+            ]}
+        ]
+    })");
+    auto result = LoadOk(j);
+    REQUIRE(result.graph->layers[0].transitions[0].trigger.key == Key::Escape);
+}
+
+TEST_CASE("Unknown key name is an error", "[flow_graph]") {
+    auto j = json::parse(R"({
+        "initial": "a",
+        "layers": [
+            { "id": "a", "kind": "screen", "transitions": [
+                { "id": "x", "to": "a", "kind": "replace",
+                  "trigger": { "type": "key", "key": "FooBar" } }
+            ]}
+        ]
+    })");
+    auto result = LoadFlowGraphFromJson(j);
+    REQUIRE_FALSE(result.ok());
+    REQUIRE(HasError(result, "unknown key"));
+}
+
+TEST_CASE("Event trigger parses 'name' field", "[flow_graph]") {
+    auto j = json::parse(R"({
+        "initial": "a",
+        "layers": [
+            { "id": "a", "kind": "screen", "transitions": [
+                { "id": "x", "to": "a", "kind": "replace",
+                  "trigger": { "type": "event", "name": "match_ended" } }
+            ]}
+        ]
+    })");
+    auto result = LoadOk(j);
+    auto const& t = result.graph->layers[0].transitions[0];
+    REQUIRE(t.trigger.kind == TriggerKind::Event);
+    REQUIRE(t.trigger.id == "match_ended");
+}
+
+TEST_CASE("Auto trigger parses afterMs", "[flow_graph]") {
+    auto j = json::parse(R"({
+        "initial": "a",
+        "layers": [
+            { "id": "a", "kind": "screen", "transitions": [
+                { "id": "auto", "to": "a", "kind": "replace",
+                  "trigger": { "type": "auto", "afterMs": 1500 } }
+            ]}
+        ]
+    })");
+    auto result = LoadOk(j);
+    REQUIRE(result.graph->layers[0].transitions[0].trigger.afterMs == 1500);
+}
+
+TEST_CASE("Unknown trigger type is an error", "[flow_graph]") {
+    auto j = json::parse(R"({
+        "initial": "a",
+        "layers": [
+            { "id": "a", "kind": "screen", "transitions": [
+                { "id": "x", "to": "a", "kind": "replace",
+                  "trigger": { "type": "telepathy" } }
+            ]}
+        ]
+    })");
+    auto result = LoadFlowGraphFromJson(j);
+    REQUIRE_FALSE(result.ok());
+    REQUIRE(HasError(result, "unknown type"));
+}
+
+TEST_CASE("Transition clip overrides parse", "[flow_graph]") {
+    auto j = json::parse(R"({
+        "initial": "a",
+        "layers": [
+            { "id": "a", "kind": "screen", "transitions": [
+                { "id": "x", "to": "a", "kind": "replace",
+                  "outClip": "custom_out", "inClip": "custom_in",
+                  "trigger": { "type": "event", "name": "e" } }
+            ]}
+        ]
+    })");
+    auto result = LoadOk(j);
+    auto const& t = result.graph->layers[0].transitions[0];
+    REQUIRE(t.outClip.value() == "custom_out");
+    REQUIRE(t.inClip.value() == "custom_in");
+}
+
+TEST_CASE("Action hook lists parse in order", "[flow_graph]") {
+    auto j = json::parse(R"({
+        "initial": "a",
+        "layers": [
+            { "id": "a", "kind": "screen", "transitions": [
+                { "id": "x", "to": "a", "kind": "replace",
+                  "trigger": { "type": "event", "name": "e" },
+                  "onStart": ["a1", "a2"],
+                  "onMidpoint": ["b1"],
+                  "onComplete": ["c1", "c2", "c3"]
+                }
+            ]}
+        ]
+    })");
+    auto result = LoadOk(j);
+    auto const& t = result.graph->layers[0].transitions[0];
+    REQUIRE(t.onStart == std::vector<ActionRef>{ "a1", "a2" });
+    REQUIRE(t.onMidpoint == std::vector<ActionRef>{ "b1" });
+    REQUIRE(t.onComplete == std::vector<ActionRef>{ "c1", "c2", "c3" });
+}
+
+TEST_CASE("FlowGraph::FindLayer", "[flow_graph]") {
+    FlowGraph g;
+    LayerSpec a; a.id = "a"; g.layers.push_back(a);
+    LayerSpec b; b.id = "b"; g.layers.push_back(b);
+
+    REQUIRE(g.FindLayer("a") != nullptr);
+    REQUIRE(g.FindLayer("a")->id == "a");
+    REQUIRE(g.FindLayer("b") != nullptr);
+    REQUIRE(g.FindLayer("c") == nullptr);
+}
+
+TEST_CASE("Validator catches missing initial", "[flow_graph][validation]") {
+    FlowGraph g;
+    g.initial = "missing";
+    LayerSpec a; a.id = "a"; g.layers.push_back(a);
+    auto errors = ValidateFlowGraph(g);
+    REQUIRE(!errors.empty());
+}
+
+TEST_CASE("Validator catches empty initial", "[flow_graph][validation]") {
+    FlowGraph g;
+    LayerSpec a; a.id = "a"; g.layers.push_back(a);
+    auto errors = ValidateFlowGraph(g);
+    REQUIRE(!errors.empty());
+}
+
+TEST_CASE("Validator catches duplicate layer ids", "[flow_graph][validation]") {
+    FlowGraph g;
+    g.initial = "a";
+    LayerSpec a; a.id = "a"; g.layers.push_back(a);
+    LayerSpec a2; a2.id = "a"; g.layers.push_back(a2);
+    auto errors = ValidateFlowGraph(g);
+    bool found = false;
+    for (auto const& e : errors) {
+        if (e.message.find("duplicate layer id") != std::string::npos) { found = true; }
+    }
+    REQUIRE(found);
+}
+
+TEST_CASE("Validator catches duplicate transition ids within layer", "[flow_graph][validation]") {
+    FlowGraph g;
+    g.initial = "a";
+    LayerSpec a; a.id = "a";
+    TransitionSpec t1; t1.id = "x"; t1.to = "a"; t1.kind = TransitionKind::Replace; a.transitions.push_back(t1);
+    TransitionSpec t2; t2.id = "x"; t2.to = "a"; t2.kind = TransitionKind::Replace; a.transitions.push_back(t2);
+    g.layers.push_back(a);
+    auto errors = ValidateFlowGraph(g);
+    bool found = false;
+    for (auto const& e : errors) {
+        if (e.message.find("duplicate transition id") != std::string::npos) { found = true; }
+    }
+    REQUIRE(found);
+}
+
+TEST_CASE("Validator: Pop must target <back>", "[flow_graph][validation]") {
+    FlowGraph g;
+    g.initial = "a";
+    LayerSpec a; a.id = "a";
+    TransitionSpec t; t.id = "x"; t.to = "a"; t.kind = TransitionKind::Pop;
+    a.transitions.push_back(t);
+    g.layers.push_back(a);
+    auto errors = ValidateFlowGraph(g);
+    bool found = false;
+    for (auto const& e : errors) {
+        if (e.message.find("Pop transitions must target '<back>'") != std::string::npos) { found = true; }
+    }
+    REQUIRE(found);
+}
+
+TEST_CASE("Validator: non-Pop may not target <back>", "[flow_graph][validation]") {
+    FlowGraph g;
+    g.initial = "a";
+    LayerSpec a; a.id = "a";
+    TransitionSpec t; t.id = "x"; t.to = std::string(kBackTarget); t.kind = TransitionKind::Replace;
+    a.transitions.push_back(t);
+    g.layers.push_back(a);
+    auto errors = ValidateFlowGraph(g);
+    bool found = false;
+    for (auto const& e : errors) {
+        if (e.message.find("only Pop transitions may target '<back>'") != std::string::npos) { found = true; }
+    }
+    REQUIRE(found);
+}
+
+TEST_CASE("Validator: unknown target layer is an error", "[flow_graph][validation]") {
+    FlowGraph g;
+    g.initial = "a";
+    LayerSpec a; a.id = "a";
+    TransitionSpec t; t.id = "x"; t.to = "ghost"; t.kind = TransitionKind::Replace;
+    a.transitions.push_back(t);
+    g.layers.push_back(a);
+    auto errors = ValidateFlowGraph(g);
+    bool found = false;
+    for (auto const& e : errors) {
+        if (e.message.find("unknown layer 'ghost'") != std::string::npos) { found = true; }
+    }
+    REQUIRE(found);
+}
+
+TEST_CASE("Validator: Push must target an Overlay", "[flow_graph][validation]") {
+    FlowGraph g;
+    g.initial = "a";
+    LayerSpec a; a.id = "a"; a.kind = LayerKind::Screen;
+    LayerSpec b; b.id = "b"; b.kind = LayerKind::Screen;  // target is Screen, not Overlay
+    TransitionSpec t; t.id = "x"; t.to = "b"; t.kind = TransitionKind::Push;
+    a.transitions.push_back(t);
+    g.layers.push_back(a);
+    g.layers.push_back(b);
+    auto errors = ValidateFlowGraph(g);
+    bool found = false;
+    for (auto const& e : errors) {
+        if (e.message.find("Push must target an Overlay") != std::string::npos) { found = true; }
+    }
+    REQUIRE(found);
+}
+
+TEST_CASE("Validator reports all errors at once, not just the first", "[flow_graph][validation]") {
+    FlowGraph g;
+    g.initial = "missing";
+    LayerSpec a; a.id = "a";
+    TransitionSpec t1; t1.id = "x"; t1.to = "ghost"; t1.kind = TransitionKind::Replace;
+    a.transitions.push_back(t1);
+    TransitionSpec t2; t2.id = "y"; t2.to = std::string(kBackTarget); t2.kind = TransitionKind::Replace;
+    a.transitions.push_back(t2);
+    g.layers.push_back(a);
+    auto errors = ValidateFlowGraph(g);
+    REQUIRE(errors.size() >= 3);  // initial missing, ghost target, <back> on non-pop
+}
+
+TEST_CASE("Loader runs the validator", "[flow_graph]") {
+    auto j = json::parse(R"({
+        "initial": "ghost",
+        "layers": [ { "id": "a", "kind": "screen" } ]
+    })");
+    auto result = LoadFlowGraphFromJson(j);
+    REQUIRE_FALSE(result.ok());
+}

--- a/tests/src/test_layer_stack.cpp
+++ b/tests/src/test_layer_stack.cpp
@@ -182,3 +182,146 @@ TEST_CASE("LayerStack size changes are reflected", "[layer_stack]") {
     REQUIRE(stack.GetWindowWidth() == 3840);
     REQUIRE(stack.GetWindowHeight() == 2160);
 }
+
+namespace {
+    class ModalTestLayer : public Layer {
+    public:
+        bool eventReceived = false;
+        bool updateReceived = false;
+        bool modal = false;
+
+        bool IsModal() const override { return modal || Layer::IsModal(); }
+
+        bool OnEvent(Event const&) override {
+            eventReceived = true;
+            return false;  // never consume — we want to see who else gets the event
+        }
+        void Update(uint32_t) override { updateReceived = true; }
+    };
+}
+
+TEST_CASE("Modal layer blocks events from reaching layers below", "[layer_stack][modal]") {
+    MockRenderer renderer;
+    LayerStack stack(renderer, {800, 600}, {800, 600});
+
+    auto bottom = std::make_unique<ModalTestLayer>();
+    auto middle = std::make_unique<ModalTestLayer>();
+    auto top = std::make_unique<ModalTestLayer>();
+    auto* bottomPtr = bottom.get();
+    auto* middlePtr = middle.get();
+    auto* topPtr = top.get();
+    middlePtr->modal = true;
+
+    stack.PushLayer(std::move(bottom));
+    stack.PushLayer(std::move(middle));
+    stack.PushLayer(std::move(top));
+
+    TestEvent ev;
+    stack.OnEvent(ev);
+
+    REQUIRE(topPtr->eventReceived);     // top of stack: yes
+    REQUIRE(middlePtr->eventReceived);  // modal layer itself: yes
+    REQUIRE_FALSE(bottomPtr->eventReceived);  // beneath the modal: blocked
+}
+
+TEST_CASE("Modal layer suspends Update on layers below", "[layer_stack][modal]") {
+    MockRenderer renderer;
+    LayerStack stack(renderer, {800, 600}, {800, 600});
+
+    auto bottom = std::make_unique<ModalTestLayer>();
+    auto modal = std::make_unique<ModalTestLayer>();
+    auto top = std::make_unique<ModalTestLayer>();
+    auto* bottomPtr = bottom.get();
+    auto* modalPtr = modal.get();
+    auto* topPtr = top.get();
+    modalPtr->modal = true;
+
+    stack.PushLayer(std::move(bottom));
+    stack.PushLayer(std::move(modal));
+    stack.PushLayer(std::move(top));
+
+    stack.Update(16);
+
+    REQUIRE(topPtr->updateReceived);
+    REQUIRE(modalPtr->updateReceived);
+    REQUIRE_FALSE(bottomPtr->updateReceived);
+}
+
+TEST_CASE("No modal layer means normal dispatch", "[layer_stack][modal]") {
+    MockRenderer renderer;
+    LayerStack stack(renderer, {800, 600}, {800, 600});
+
+    auto bottom = std::make_unique<ModalTestLayer>();
+    auto top = std::make_unique<ModalTestLayer>();
+    auto* bottomPtr = bottom.get();
+    auto* topPtr = top.get();
+
+    stack.PushLayer(std::move(bottom));
+    stack.PushLayer(std::move(top));
+
+    TestEvent ev;
+    stack.OnEvent(ev);
+    stack.Update(16);
+
+    REQUIRE(topPtr->eventReceived);
+    REQUIRE(bottomPtr->eventReceived);
+    REQUIRE(topPtr->updateReceived);
+    REQUIRE(bottomPtr->updateReceived);
+}
+
+TEST_CASE("Topmost modal acts as the cutoff when multiple modals exist", "[layer_stack][modal]") {
+    MockRenderer renderer;
+    LayerStack stack(renderer, {800, 600}, {800, 600});
+
+    auto bottom = std::make_unique<ModalTestLayer>();
+    auto lowerModal = std::make_unique<ModalTestLayer>();
+    auto between = std::make_unique<ModalTestLayer>();
+    auto upperModal = std::make_unique<ModalTestLayer>();
+    auto top = std::make_unique<ModalTestLayer>();
+    auto* bottomPtr = bottom.get();
+    auto* lowerModalPtr = lowerModal.get();
+    auto* betweenPtr = between.get();
+    auto* upperModalPtr = upperModal.get();
+    auto* topPtr = top.get();
+    lowerModalPtr->modal = true;
+    upperModalPtr->modal = true;
+
+    stack.PushLayer(std::move(bottom));
+    stack.PushLayer(std::move(lowerModal));
+    stack.PushLayer(std::move(between));
+    stack.PushLayer(std::move(upperModal));
+    stack.PushLayer(std::move(top));
+
+    stack.Update(16);
+
+    REQUIRE(topPtr->updateReceived);
+    REQUIRE(upperModalPtr->updateReceived);
+    REQUIRE_FALSE(betweenPtr->updateReceived);
+    REQUIRE_FALSE(lowerModalPtr->updateReceived);
+    REQUIRE_FALSE(bottomPtr->updateReceived);
+}
+
+TEST_CASE("SetModal flips the default IsModal", "[layer_stack][modal]") {
+    MockRenderer renderer;
+    LayerStack stack(renderer, {800, 600}, {800, 600});
+
+    auto bottom = std::make_unique<TestLayer>();
+    auto top = std::make_unique<TestLayer>();
+    auto* bottomPtr = bottom.get();
+    auto* topPtr = top.get();
+    topPtr->SetModal(true);
+
+    stack.PushLayer(std::move(bottom));
+    stack.PushLayer(std::move(top));
+
+    stack.Update(16);
+    REQUIRE(topPtr->updateCalled);
+    REQUIRE_FALSE(bottomPtr->updateCalled);
+
+    topPtr->SetModal(false);
+    bottomPtr->updateCalled = false;
+    topPtr->updateCalled = false;
+    stack.Update(16);
+    REQUIRE(topPtr->updateCalled);
+    REQUIRE(bottomPtr->updateCalled);
+}


### PR DESCRIPTION
## Summary
- Adds `moth_ui/flow/` — a serialisable navigation system on top of `LayerStack`. Apps load a `FlowGraph` (JSON or in-code), register layer factories + side-effect actions, and the runtime drives transitions through a fixed phase machine: `onStart → OutAnimating → stack mutation → onMidpoint → InAnimating → onComplete`. Push/Pop/Replace transition kinds; button/key/event/auto triggers; queued or rejected re-entry; per-phase timeout watchdog.
- Provides `TransitioningLayer` (clip-driven, `.mothui`-backed) and `CodeDrivenLayer` bases via the new `ITransitionParticipant` contract. Cached layer construction supported for layers that need to outlive a single visit.
- New `IClickable` interface plus a bundled `UIButton` widget that implements it. Flow auto-wires button triggers by `dynamic_cast<IClickable*>` on layout nodes — no per-app boilerplate.
- `Layer::IsModal/SetModal` + `LayerStack` modal cutoff: events and `Update` stop at the topmost modal layer, beneath layers are paused automatically.
- `EnsureWidgetsRegistered()` umbrella keeps bundled widgets' static initialisers from being stripped when moth_ui is consumed as a static library.
- Moves `widget.h` and `ui_button.{h,cpp}` from `nodes/` to `widgets/`.
- Design doc lives at `docs/flow_system_design.md`.

The entire utility is opt-in — apps that don't `#include "moth_ui/flow/..."` are unaffected. No moth_graphics dependency was added.

## Test plan
- [ ] Build moth_ui Debug (clang-tidy on) and Release on Linux + Windows
- [ ] Build a downstream consumer (scorched_moth on its own `feature/flow-system`) and exercise:
  - [ ] Title → Game (Replace with `onMidpoint` action)
  - [ ] Esc → pause overlay push (modal cutoff suspends GameLayer)
  - [ ] Resume button + Esc on pause (Pop) — game becomes interactive again
  - [ ] Match-end → game_over overlay push (programmatic Emit)
  - [ ] Replay (Pop + `onMidpoint` `session.NewMatch`)
  - [ ] Quit from pause / game_over (chained Pop → event-triggered Replace to title, game_hud plays transition_out)
- [ ] Confirm first frame of an overlay shows the start of `transition_in` (no idle-frame flash); `Flow::Tick` pumps synchronous phases
- [ ] Confirm bundled UIButton clicks fire when only the layout JSON names the `"button"` class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flow navigation runtime with JSON-configurable flow graphs, transition state machine, and registries for layer factories and named actions; added code-driven and transition layers plus clickable activation support.
  * New UIButton and UIScrollView widgets; added an opt-in widget registration helper.
  * Modal-layer behavior, enhanced input capture (Node/Group), and LayerStack layer detaching for reuse.
  * Mouse wheel events now include cursor position.
* **Documentation**
  * Added Flow system design and consumer guide.
* **Tests**
  * Expanded unit coverage for flow/graph validation, modal behavior, and event dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->