### PR TITLE
fix: assign vector elements without reinterpret_cast

### DIFF
--- a/include/moth_ui/utils/vector.h
+++ b/include/moth_ui/utils/vector.h
@@ -86,7 +86,10 @@ namespace moth_ui {
          */
         template <class... Scalars, std::enable_if_t<Dim >= 2 && std::conjunction_v<std::is_convertible<Scalars, T>...> && sizeof...(Scalars) == Dim, bool> = true>
         Vector(Scalars... scalars) {
-            *reinterpret_cast<std::array<T, Dim>*>(data) = { T(scalars)... };
+            T const values[Dim] = { T(scalars)... };
+            for (int i = 0; i < Dim; ++i) {
+                data[i] = values[i];
+            }
         }
 
         /**


### PR DESCRIPTION
## Problem

`Vector`'s scalar constructor wrote through a `reinterpret_cast<std::array<T, Dim>*>(data)`. Because `Vector` is `#pragma pack(1)` (`alignof == 1`), this is a strict-aliasing violation that **GCC miscompiles under `-O2`/`-O3`**: the constructed elements read back as garbage (and GCC emits a `'used uninitialized'` warning). MSVC tolerated the UB, so it only surfaced on Linux Release builds.

Surfaced by moth_graphics' new polygon-triangulation tests: constructing `FloatVec2{x, y}` in a tight loop returned garbage coordinates, so triangulation produced no triangles and the tests failed on Linux only.

## Fix

Assign the elements element-wise into `data` instead of type-punning through `std::array`. No `reinterpret_cast`, no aliasing violation.

## Testing

Verified the packed `Vector` constructs correctly for Dim 2/3/4 (including the `x/y/z/w` and `r/g/b/a` union aliases) under `-O2` and `-O3` with `-Wall -Wextra` — no warnings, correct values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vector construction from multiple scalar values, ensuring values are converted and stored reliably across supported types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->